### PR TITLE
fix: implement sticky header for leaderboard table to prevent context loss

### DIFF
--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -32,7 +32,6 @@
 }
 
 html, body {
-  overflow-x: hidden;
   width: 100%;
   max-width: 100vw;
 }
@@ -463,6 +462,7 @@ body::after {
   color: var(--text);
   padding: 2rem 1rem;
   animation: fadeIn 0.4s ease-out;
+  overflow-x: clip;
 }
 
 .page-title {
@@ -678,12 +678,12 @@ body::after {
   color: var(--bg);
 }
 
-/* ── Leaderboard ── */
+/* --- Leaderboard --- */
 .leaderboard {
   background: var(--bg-surface);
   border: 1px solid var(--border-bright);
   border-radius: 6px;
-  overflow: hidden;
+  overflow: visible;
   box-shadow: 0 0 30px rgba(0, 255, 65, 0.03);
 }
 
@@ -698,6 +698,9 @@ body::after {
   letter-spacing: 1px;
   color: var(--green-dim);
   border-bottom: 1px solid var(--border-bright);
+  position: sticky;
+  top: 52px;
+  z-index: 99;
 }
 
 .leaderboard-row {


### PR DESCRIPTION
Fixes #38 

**Changes made:**
- Implemented `position: sticky` to `.leaderboard-header` for continuous context visibility.
- Replaced `overflow-x: hidden` with `overflow-x: clip` on `.page` to preserve the sticky context without breaking horizontal bounds.
- Accurately calculated the `top` offset to perfectly align right below the existing sticky Navbar without overlaps or transparent gaps.
- Adjusted `z-index` so scrolling rows pass cleanly beneath the header.


https://github.com/user-attachments/assets/5e1b0205-3e7b-4c81-9ba3-dcb66386c3be

