### PR TITLE
fix: add missing let/const declarations in sync-leaderboard.js (#60)

### DIFF
--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -99,11 +99,11 @@ function getFileName(daysAgo) {
     process.exit(1);
   }
 
-  dailyData = JSON.parse(JSON.stringify(overallData));
+  let dailyData = JSON.parse(JSON.stringify(overallData));
   console.log(" ");
   console.log("Loading previous day's file...");
   const previousDayFilepath = path.join(DATA_DIR, "daily", getFileName(1));
-  previousData = [];
+  let previousData = [];
   try {
     const rawData = fs.readFileSync(previousDayFilepath, "utf8");
     previousData = JSON.parse(rawData);
@@ -152,7 +152,7 @@ function getFileName(daysAgo) {
     process.exit(1);
   }
 
-  weeklyData = JSON.parse(JSON.stringify(overallData));
+  let weeklyData = JSON.parse(JSON.stringify(overallData));
   console.log(" ");
   console.log("Loading previous week's file...");
   const previousWeekFilepath = path.join(DATA_DIR, "daily", getFileName(7));
@@ -211,7 +211,7 @@ function getFileName(daysAgo) {
     process.exit(1);
   }
 
-  monthlyData = JSON.parse(JSON.stringify(overallData));
+  let monthlyData = JSON.parse(JSON.stringify(overallData));
   console.log(" ");
   console.log("Loading previous month's file...");
   const previousMonthFilepath = path.join(DATA_DIR, "daily", getFileName(30));


### PR DESCRIPTION
## Summary

Adds missing let/const declarations to variables used without declaration in sync-leaderboard.js. Fixes #60.

## Changes
- Added 'let' to dailyData, weeklyData, monthlyData, and the first previousData declaration