### PR TITLE
fix: prevent process.exit(1) on single user API failure (#61)

### DIFF
--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -12,7 +12,7 @@ async function fetchData(url) {
     };
   } catch (err) {
     console.error("API failed to respond: ", err.message);
-    process.exit(1);
+    return null;
   }
 }
 
@@ -53,6 +53,10 @@ function getFileName(daysAgo) {
   console.log("Starting daily fetch...");
   for (const user of users) {
     const data = await fetchData(baseUrl + user.id);
+    if (!data) {
+      console.log(`${user.name}: skipped (API error)`);
+      continue;
+    }
     const score = data.easySolved + data.mediumSolved * 3 + data.hardSolved * 5;
     console.log(`${user.name}:`, data);
     overallData.push({


### PR DESCRIPTION
## Summary

Prevents process.exit(1) when a single user's LeetCode API call fails. Instead of terminating the entire sync, failed user fetches are logged and skipped. Fixes #61.

## Changes
- fetchData() now returns null instead of calling process.exit(1) on API error
- The user processing loop skips users whose API call returned null