### PR TITLE
perf: fetch leaderboard data files concurrently using Promise.allSettled

### DIFF
--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -227,19 +227,25 @@
       async function fetchLeaderboardData() {
         const endpoints = ["overall", "monthly", "weekly", "daily"];
         const cacheBuster = Date.now();
-        for (const type of endpoints) {
-          // Fetch directly from github to avoid needing a server redeploy for new data
-          try {
-            const response = await fetch(
+        // Fetch directly from github to avoid needing a server redeploy for new data
+        const results = await Promise.allSettled(
+          endpoints.map((type) =>
+            fetch(
               `https://raw.githubusercontent.com/codepvg/leetcode-ranking-data/main/${type}.json?t=${cacheBuster}`,
-            );
-            if (response.ok) {
-              leaderboardData[type] = await response.json();
-            }
-          } catch (e) {
-            console.error("Failed to fetch", type);
+            ).then((res) => {
+              if (!res.ok) throw new Error(`Failed to fetch ${type}`);
+              return res.json();
+            }),
+          ),
+        );
+
+        results.forEach((result, index) => {
+          if (result.status === "fulfilled") {
+            leaderboardData[endpoints[index]] = result.value;
+          } else {
+            console.error("Failed to fetch", endpoints[index], result.reason);
           }
-        }
+        });
 
         try {
           // Fetch directly from github to avoid needing a server redeploy for new data


### PR DESCRIPTION
## Description

Replaces the sequential `await` inside `for...of` loop in `fetchLeaderboardData()` with `Promise.allSettled()` so all four JSON files (overall, monthly, weekly, daily) are fetched concurrently instead of one after another, reducing leaderboard load time significantly.

### Linked Issue
Fixes #68

### Changes Made
- Replaced sequential `for...of` fetch loop with `Promise.allSettled()` in `fetchLeaderboardData()` inside `frontend/leaderboard.html`

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor

## Testing
- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist
- [x] My code follows the project's coding style
- [x] I have formatted my code locally using Prettier
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

This is a performance and logic change with no UI modifications.
Verified using Chrome DevTools Network tab with Disable cache enabled.

**Before — sequential fetching (for...of with await):**

<img width="708" height="289" alt="old1" src="https://github.com/user-attachments/assets/0d0bc7b2-207d-428c-ab06-423776d99927" />

**After — concurrent fetching (Promise.allSettled):**
<img width="491" height="171" alt="new1" src="https://github.com/user-attachments/assets/dbf8c269-6f03-4b28-86e4-7194b4f77a7e" />
Disable cache was enabled in Chrome DevTools to ensure fresh 
network requests on each reload, giving accurate timing results.