### PR TITLE
Added dynamic clear button to leaderboard search

### DIFF
--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -81,7 +81,7 @@
               autocomplete="off"
               spellcheck="false"
             />
-            
+
             <span class="search-result-count" id="search-result-count"></span>
             <kbd class="search-shortcut" id="search-shortcut">Ctrl+K</kbd>
             <button
@@ -159,21 +159,21 @@
 
         searchInput.addEventListener("input", (e) => {
           currentSearchTerm = e.target.value.toLowerCase().trim();
-          
+
           clearBtn.style.display =
-          e.target.value.trim() !== "" ? "flex" : "none";
+            e.target.value.trim() !== "" ? "flex" : "none";
 
           applyFiltersAndRender();
         });
         clearBtn.addEventListener("click", () => {
-  searchInput.value = "";
-  currentSearchTerm = "";
+          searchInput.value = "";
+          currentSearchTerm = "";
 
-  clearBtn.style.display = "none";
+          clearBtn.style.display = "none";
 
-  searchInput.focus();
-  applyFiltersAndRender();
-});
+          searchInput.focus();
+          applyFiltersAndRender();
+        });
 
         searchInput.addEventListener("focus", () => {
           shortcutBadge.style.display = "none";
@@ -220,7 +220,7 @@
               applyFiltersAndRender();
             }
           });
-          clearBtn.style.display = "none";
+        clearBtn.style.display = "none";
         fetchLeaderboardData();
       });
 

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -81,6 +81,14 @@
               autocomplete="off"
               spellcheck="false"
             />
+            <button
+              type="button"
+              id="clear-search"
+              class="clear-search-btn"
+              aria-label="Clear search"
+            >
+              ✕
+            </button>
             <span class="search-result-count" id="search-result-count"></span>
             <kbd class="search-shortcut" id="search-shortcut">Ctrl+K</kbd>
           </div>
@@ -146,11 +154,25 @@
 
         const searchInput = document.getElementById("leaderboard-search");
         const shortcutBadge = document.getElementById("search-shortcut");
+        const clearBtn = document.getElementById("clear-search");
 
         searchInput.addEventListener("input", (e) => {
           currentSearchTerm = e.target.value.toLowerCase().trim();
+          
+          clearBtn.style.display =
+          e.target.value.trim() !== "" ? "flex" : "none";
+
           applyFiltersAndRender();
         });
+        clearBtn.addEventListener("click", () => {
+  searchInput.value = "";
+  currentSearchTerm = "";
+
+  clearBtn.style.display = "none";
+
+  searchInput.focus();
+  applyFiltersAndRender();
+});
 
         searchInput.addEventListener("focus", () => {
           shortcutBadge.style.opacity = "0";
@@ -196,7 +218,7 @@
               applyFiltersAndRender();
             }
           });
-
+          clearBtn.style.display = "none";
         fetchLeaderboardData();
       });
 

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -90,7 +90,7 @@
               class="clear-search-btn"
               aria-label="Clear search"
             >
-              ✕
+              ESC
             </button>
           </div>
         </div>
@@ -176,12 +176,12 @@
 });
 
         searchInput.addEventListener("focus", () => {
-          shortcutBadge.style.opacity = "0";
+          shortcutBadge.style.display = "none";
         });
 
         searchInput.addEventListener("blur", () => {
           if (!searchInput.value) {
-            shortcutBadge.style.opacity = "1";
+            shortcutBadge.style.display = "inline-flex";
           }
         });
 
@@ -194,6 +194,7 @@
           if (e.key === "Escape" && document.activeElement === searchInput) {
             searchInput.value = "";
             currentSearchTerm = "";
+            clearBtn.style.display = "none";
             searchInput.blur();
             applyFiltersAndRender();
           }

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -81,6 +81,9 @@
               autocomplete="off"
               spellcheck="false"
             />
+            
+            <span class="search-result-count" id="search-result-count"></span>
+            <kbd class="search-shortcut" id="search-shortcut">Ctrl+K</kbd>
             <button
               type="button"
               id="clear-search"
@@ -89,8 +92,6 @@
             >
               ✕
             </button>
-            <span class="search-result-count" id="search-result-count"></span>
-            <kbd class="search-shortcut" id="search-shortcut">Ctrl+K</kbd>
           </div>
         </div>
 

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -2305,6 +2305,39 @@ body::-webkit-scrollbar-thumb {
   transition: opacity 0.15s ease;
   user-select: none;
 }
+.clear-search-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--red);
+  width: 26px;
+  height: 26px;
+  border-radius: 4px;
+  cursor: pointer;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  font-family: "Fira Code", monospace;
+  font-size: 0.8rem;
+
+  transition: all 0.2s ease;
+}
+
+.clear-search-btn:hover {
+  border-color: var(--red);
+  background: rgba(255, 51, 51, 0.12);
+
+  box-shadow:
+    0 0 10px rgba(255, 51, 51, 0.25),
+    inset 0 0 8px rgba(255, 51, 51, 0.08);
+
+  text-shadow: 0 0 6px rgba(255, 51, 51, 0.8);
+}
+
+.clear-search-btn:active {
+  transform: scale(0.95);
+}
 
 .no-results {
   text-align: center;

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -2306,33 +2306,26 @@ body::-webkit-scrollbar-thumb {
   user-select: none;
 }
 .clear-search-btn {
-  background: transparent;
-  border: 1px solid var(--border);
+  background: rgba(255, 51, 51, 0.05);
+  border: 1px solid rgba(255, 51, 51, 0.4);
   color: var(--red);
-  width: 26px;
-  height: 26px;
-  border-radius: 4px;
+  padding: 2px 6px;
+  border-radius: 3px;
   cursor: pointer;
-
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: center;
-
   font-family: "Fira Code", monospace;
-  font-size: 0.8rem;
-
-  transition: all 0.2s ease;
+  font-size: 0.65rem;
+  font-weight: bold;
+  transition: all 0.15s ease;
 }
 
 .clear-search-btn:hover {
+  background: rgba(255, 51, 51, 0.15);
   border-color: var(--red);
-  background: rgba(255, 51, 51, 0.12);
-
-  box-shadow:
-    0 0 10px rgba(255, 51, 51, 0.25),
-    inset 0 0 8px rgba(255, 51, 51, 0.08);
-
-  text-shadow: 0 0 6px rgba(255, 51, 51, 0.8);
+  box-shadow: 0 0 8px rgba(255, 51, 51, 0.2);
+  text-shadow: 0 0 5px rgba(255, 51, 51, 0.8);
 }
 
 .clear-search-btn:active {


### PR DESCRIPTION
## Description

The clear button remains hidden when the search field is empty, appears automatically when users start typing, and clears the search input along with the applied filters when clicked.

### Linked Issue

Fixes #79 

### Changes Made

Added a clear (✕) button inside the leaderboard search bar.
Implemented dynamic visibility based on input content.
Added functionality to instantly clear the search field.
Reset leaderboard filtering after clearing the search.
Returned focus to the search input after clearing.
Added styling for the clear button and hover states.
Kept the button hidden by default when the page loads.

## Type of Change

<!-- Put an 'x' inside the brackets that apply -->

- [x ] Bug fix
- [ ] New feature
- [ x] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

<!-- Describe how you tested your changes -->

- [ x] Tested locally
- [ x] Tested on mobile viewport (if applicable)
- [ x] No console errors introduced

## Checklist

- [ x] My code follows the project's coding style
- [ x] I have formatted my code locally using Prettier
- [ x] I have performed a self-review of my code
- [ x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [ x] I have linked the relevant issue

## Screenshots / Screen Recording

After
<img width="1363" height="597" alt="Screenshot 2026-06-02 215002" src="https://github.com/user-attachments/assets/5a662dff-22ed-4e3c-9d1c-623018ceda06" />

Before


<img width="1364" height="595" alt="Screenshot 2026-06-02 215033" src="https://github.com/user-attachments/assets/19fd1c05-b5a1-4bbc-ae48-66cec8a39dee" />
<img width="1366" height="601" alt="Screenshot 2026-06-02 214840" src="https://github.com/user-attachments/assets/29f412dd-6b38-4ad5-bff0-51931c2bf861" />
