### PR TITLE
feat: display totalSolved in leaderboard UI

### DIFF
--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -96,6 +96,7 @@
             <div class="easy">Easy</div>
             <div class="medium">Medium</div>
             <div class="hard">Hard</div>
+            <div class="total">Total</div>
             <div class="score-header">
               Score
               <div class="tooltip-container">
@@ -404,6 +405,7 @@
                     <div class="easy">${user.data.easySolved}</div>
                     <div class="medium">${user.data.mediumSolved}</div>
                     <div class="hard">${user.data.hardSolved}</div>
+                    <div class="total">${user.data.totalSolved}</div>
                     <div class="mobile-score tooltip-score">
                             <span>${user.score}</span>
                              <span class="score-caret"></span>
@@ -416,6 +418,9 @@
                             </div>
                             <div>
                                 Hard: ${user.data.hardSolved} × ${hardPoints} = ${hardScore}
+                            </div>
+                            <div>
+                              Questions Solved: ${user.data.totalSolved}
                             </div>
                             <hr>
                             <div>
@@ -443,6 +448,9 @@
                                 </div>
                                 <div>
                                     Hard: ${user.data.hardSolved} × ${hardPoints} = ${hardScore}
+                                </div>
+                                <div>
+                                  Questions Solved: ${user.data.totalSolved}
                                 </div>
                                 <hr>
                                 <div>
@@ -475,6 +483,10 @@
                         <div class="mobile-stat">
                             <div class="mobile-stat-number hard">${user.data.hardSolved}</div>
                             <div class="mobile-stat-label">Hard</div>
+                        </div>
+                        <div class="mobile-stat">
+                            <div class="mobile-stat-number total">${user.data.totalSolved}</div>
+                            <div class="mobile-stat-label">Total</div>
                         </div>
                     </div>
                 `;

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -832,7 +832,7 @@ body::after {
   z-index: 99;
 }
 
-.leaderboard-row{
+.leaderboard-row {
   display: grid;
   grid-template-columns: 55px 1fr 170px 65px 65px 65px 85px 85px;
   padding: 0.6rem 1.25rem;
@@ -1008,7 +1008,7 @@ body::after {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 0.5rem;
-  gap:12px;
+  gap: 12px;
 }
 
 .mobile-rank {
@@ -1026,7 +1026,7 @@ body::after {
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
-  gap:6px;
+  gap: 6px;
 }
 
 .mobile-name {
@@ -1035,7 +1035,7 @@ body::after {
   margin-bottom: 0.2rem;
   color: var(--text);
   word-break: break-word;
-  overflow-wrap:break-word;
+  overflow-wrap: break-word;
 }
 
 .mobile-username {

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -818,7 +818,7 @@ body::after {
 
 .leaderboard-header {
   display: grid;
-  grid-template-columns: 55px 1fr 170px 65px 65px 65px 85px;
+  grid-template-columns: 55px 1fr 170px 65px 65px 65px 85px 85px;
   padding: 0.7rem 1.25rem;
   background: var(--bg-raised);
   font-weight: 700;
@@ -832,9 +832,9 @@ body::after {
   z-index: 99;
 }
 
-.leaderboard-row {
+.leaderboard-row{
   display: grid;
-  grid-template-columns: 55px 1fr 170px 65px 65px 65px 85px;
+  grid-template-columns: 55px 1fr 170px 65px 65px 65px 85px 85px;
   padding: 0.6rem 1.25rem;
   border-bottom: 1px solid var(--border);
   transition: background 0.1s ease;
@@ -1008,6 +1008,7 @@ body::after {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 0.5rem;
+  gap:12px;
 }
 
 .mobile-rank {
@@ -1021,6 +1022,11 @@ body::after {
   font-weight: 700;
   color: var(--amber);
   text-shadow: 0 0 6px rgba(255, 176, 0, 0.3);
+  white-space: nowrap !important;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap:6px;
 }
 
 .mobile-name {
@@ -1028,6 +1034,8 @@ body::after {
   font-weight: 600;
   margin-bottom: 0.2rem;
   color: var(--text);
+  word-break: break-word;
+  overflow-wrap:break-word;
 }
 
 .mobile-username {
@@ -1622,8 +1630,8 @@ body::after {
 
 @media (max-width: 768px) {
   .score-tooltip {
-    left: auto;
-    right: 0;
+    left: auto !important;
+    right: -10px !important;
     /* left: 50%; */
     transform: translateX(0%);
     white-space: normal;
@@ -2183,7 +2191,7 @@ body::-webkit-scrollbar-thumb {
 .tooltip-score {
   position: relative;
   cursor: pointer;
-  display: inline-flex;
+  display: inline-flex !important;
   /* key fix */
   width: fit-content;
   align-items: center;
@@ -2192,6 +2200,7 @@ body::-webkit-scrollbar-thumb {
   color: #ffffff;
   font-weight: 700;
   text-shadow: 0 0 8px rgba(255, 255, 255, 0.25);
+  flex-shrink: 0;
 }
 
 .score-tooltip {


### PR DESCRIPTION
## Description

Currently, the leaderboard does not display the total number of questions solved by each user. Although the workflow now includes the `totalSolved` field, it is not being shown in the UI.
We need to update the leaderboard to display this value for each user.

### Linked Issue

Fixes #22

### Changes Made


- Display the total number of questions solved for each user on the leaderboard
- Value should be read from:

## Type of Change

<!-- Put an 'x' inside the brackets that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

<!-- Describe how you tested your changes -->

- [x] Tested locally
- [x] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally using Prettier
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

<!-- Required for UI/Visual changes whenever possible -->
Desktop View
<img width="1474" height="873" alt="Screenshot 2026-06-04 112419" src="https://github.com/user-attachments/assets/9fbcd3ee-72eb-492a-80a9-6100737fd291" />
Mobile view
<img width="345" height="743" alt="Screenshot 2026-06-04 112446" src="https://github.com/user-attachments/assets/38fb228b-d998-4f9a-a8cb-3dbc23fd2aea" />


