### PR TITLE
added 404 website themed page

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -185,7 +185,7 @@
           box-sizing: border-box;
         }
       }
-    </style>    
+    </style>
   </head>
 
   <body>

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -64,17 +64,6 @@
         margin-bottom: 0.4rem;
       }
 
-      .title .cursor {
-        display: inline-block;
-        width: 3px;
-        height: 2.2rem;
-        background: var(--green);
-        vertical-align: middle;
-        margin-left: 4px;
-        animation: blink 1s step-end infinite;
-        box-shadow: 0 0 8px var(--green);
-      }
-
       @keyframes blink {
         50% {
           opacity: 0;
@@ -178,9 +167,7 @@
         .title {
           font-size: 1.6rem;
         }
-        .title .cursor {
-          height: 1.5rem;
-        }
+
         .subtitle {
           font-size: 0.75rem;
         }
@@ -205,7 +192,7 @@
     <canvas id="matrix"></canvas>
 
     <div class="panel">
-      <div class="title">404 — Not Found<span class="cursor"></span></div>
+      <div class="title">404 — Not Found</div>
       <div class="subtitle">
         &gt; route resolution failed. filesystem integrity nominal.
       </div>

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -170,7 +170,35 @@
         pointer-events: none;
         z-index: 2;
       }
-    </style>
+      @media (max-width: 480px) {
+        .panel {
+          padding: 1.5rem 1.2rem;
+          width: 95%;
+        }
+        .title {
+          font-size: 1.6rem;
+        }
+        .title .cursor {
+          height: 1.5rem;
+        }
+        .subtitle {
+          font-size: 0.75rem;
+        }
+        .line {
+          font-size: 0.82rem;
+          line-height: 1.6;
+        }
+        .nav-links {
+          flex-direction: column;
+          gap: 0.75rem;
+        }
+        .nav-links a {
+          text-align: center;
+          width: 100%;
+          box-sizing: border-box;
+        }
+      }
+    </style>    
   </head>
 
   <body>

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -1,271 +1,294 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>404 — Not Found | CodePVG</title>
-  <link rel="icon" type="image/png" href="assets/logo.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Space+Mono:wght@400;700&family=Share+Tech+Mono&display=swap"
-    rel="stylesheet"
-  />
-  <link rel="stylesheet" href="styles/main.css" />
-  <style>
-    /* 404-specific overrides */
-    body {
-      background: var(--bg);
-      color: var(--green);
-      font-family: 'Share Tech Mono', 'Courier New', monospace;
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      overflow: hidden;
-      position: relative;
-    }
-
-    /* Matrix rain canvas */
-    #matrix {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      z-index: 0;
-      opacity: 0.18;
-    }
-
-    /* Main panel */
-    .panel {
-      position: relative;
-      z-index: 1;
-      background: rgba(0, 10, 0, 0.85);
-      border: 1px solid rgba(0, 255, 65, 0.3);
-      border-radius: 4px;
-      padding: 2.5rem 3rem;
-      max-width: 680px;
-      width: 90%;
-      box-shadow: 0 0 40px rgba(0, 255, 65, 0.08), inset 0 0 60px rgba(0, 0, 0, 0.5);
-    }
-
-    /* Title */
-    .title {
-      font-size: 2.4rem;
-      font-weight: normal;
-      color: var(--green);
-      text-shadow: 0 0 20px rgba(0, 255, 65, 0.4), 0 0 40px rgba(0, 255, 65, 0.4);
-      letter-spacing: 2px;
-      margin-bottom: 0.4rem;
-    }
-
-    .title .cursor {
-      display: inline-block;
-      width: 3px;
-      height: 2.2rem;
-      background: var(--green);
-      vertical-align: middle;
-      margin-left: 4px;
-      animation: blink 1s step-end infinite;
-      box-shadow: 0 0 8px var(--green);
-    }
-
-    @keyframes blink {
-      50% {
-        opacity: 0;
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>404 — Not Found | CodePVG</title>
+    <link rel="icon" type="image/png" href="assets/logo.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Space+Mono:wght@400;700&family=Share+Tech+Mono&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles/main.css" />
+    <style>
+      /* 404-specific overrides */
+      body {
+        background: var(--bg);
+        color: var(--green);
+        font-family: "Share Tech Mono", "Courier New", monospace;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        position: relative;
       }
-    }
 
-    .subtitle {
-      color: #4a8c4a;
-      font-size: 0.85rem;
-      margin-bottom: 2rem;
-    }
+      /* Matrix rain canvas */
+      #matrix {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 0;
+        opacity: 0.18;
+      }
 
-    /* Terminal lines */
-    .terminal-block {
-      margin-bottom: 1.4rem;
-    }
+      /* Main panel */
+      .panel {
+        position: relative;
+        z-index: 1;
+        background: rgba(0, 10, 0, 0.85);
+        border: 1px solid rgba(0, 255, 65, 0.3);
+        border-radius: 4px;
+        padding: 2.5rem 3rem;
+        max-width: 680px;
+        width: 90%;
+        box-shadow:
+          0 0 40px rgba(0, 255, 65, 0.08),
+          inset 0 0 60px rgba(0, 0, 0, 0.5);
+      }
 
-    .line {
-      line-height: 1.8;
-      font-size: 0.95rem;
-    }
+      /* Title */
+      .title {
+        font-size: 2.4rem;
+        font-weight: normal;
+        color: var(--green);
+        text-shadow:
+          0 0 20px rgba(0, 255, 65, 0.4),
+          0 0 40px rgba(0, 255, 65, 0.4);
+        letter-spacing: 2px;
+        margin-bottom: 0.4rem;
+      }
 
-    .prompt {
-      color: var(--green);
-      text-shadow: 0 0 8px rgba(0, 255, 65, 0.4);
-    }
+      .title .cursor {
+        display: inline-block;
+        width: 3px;
+        height: 2.2rem;
+        background: var(--green);
+        vertical-align: middle;
+        margin-left: 4px;
+        animation: blink 1s step-end infinite;
+        box-shadow: 0 0 8px var(--green);
+      }
 
-    .prompt-sym {
-      color: var(--green-dim);
-    }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
 
-    .cmd {
-      color: #c9e8c9;
-    }
+      .subtitle {
+        color: #4a8c4a;
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+      }
 
-    .error-line {
-      color: var(--red);
-      text-shadow: 0 0 8px rgba(255, 68, 68, 0.4);
-    }
+      /* Terminal lines */
+      .terminal-block {
+        margin-bottom: 1.4rem;
+      }
 
-    .comment {
-      color: #4a8c4a;
-    }
+      .line {
+        line-height: 1.8;
+        font-size: 0.95rem;
+      }
 
-    .highlight {
-      color: var(--green);
-      font-weight: bold;
-      text-shadow: 0 0 10px rgba(0, 255, 65, 0.4);
-    }
+      .prompt {
+        color: var(--green);
+        text-shadow: 0 0 8px rgba(0, 255, 65, 0.4);
+      }
 
-    .highlight a {
-      color: inherit;
-      text-decoration: none;
-      transition: color 0.15s ease;
-    }
+      .prompt-sym {
+        color: var(--green-dim);
+      }
 
-    .highlight a:hover {
-      color: #66ffaa;
-      text-shadow: 0 0 12px rgba(0, 255, 65, 0.4);
-    }
+      .cmd {
+        color: #c9e8c9;
+      }
 
-    /* Divider */
-    .divider {
-      border: none;
-      border-top: 1px solid rgba(0, 255, 65, 0.3);
-      margin: 1.4rem 0;
-    }
+      .error-line {
+        color: var(--red);
+        text-shadow: 0 0 8px rgba(255, 68, 68, 0.4);
+      }
 
-    /* Button area — centered */
-    .nav-links {
-      display: flex;
-      gap: 1.2rem;
-      flex-wrap: wrap;
-      margin-top: 1.8rem;
-      justify-content: center;
-    }
+      .comment {
+        color: #4a8c4a;
+      }
 
-    /* Scanline overlay */
-    body::after {
-      content: '';
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background: repeating-linear-gradient(0deg,
+      .highlight {
+        color: var(--green);
+        font-weight: bold;
+        text-shadow: 0 0 10px rgba(0, 255, 65, 0.4);
+      }
+
+      .highlight a {
+        color: inherit;
+        text-decoration: none;
+        transition: color 0.15s ease;
+      }
+
+      .highlight a:hover {
+        color: #66ffaa;
+        text-shadow: 0 0 12px rgba(0, 255, 65, 0.4);
+      }
+
+      /* Divider */
+      .divider {
+        border: none;
+        border-top: 1px solid rgba(0, 255, 65, 0.3);
+        margin: 1.4rem 0;
+      }
+
+      /* Button area — centered */
+      .nav-links {
+        display: flex;
+        gap: 1.2rem;
+        flex-wrap: wrap;
+        margin-top: 1.8rem;
+        justify-content: center;
+      }
+
+      /* Scanline overlay */
+      body::after {
+        content: "";
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: repeating-linear-gradient(
+          0deg,
           transparent,
           transparent 2px,
           rgba(0, 0, 0, 0.05) 2px,
-          rgba(0, 0, 0, 0.05) 4px);
-      pointer-events: none;
-      z-index: 2;
-    }
-  </style>
-</head>
-
-<body>
-
-  <canvas id="matrix"></canvas>
-
-  <div class="panel">
-
-    <div class="title">404 — Not Found<span class="cursor"></span></div>
-    <div class="subtitle">&gt; route resolution failed. filesystem integrity nominal.</div>
-
-    <hr class="divider" />
-
-    <div class="terminal-block">
-      <div class="line">
-        <span class="prompt">guest@codepvg</span><span class="prompt-sym">:~$</span>
-        <span class="cmd" id="cd-line"> cd /unknown-path</span>
-      </div>
-      <div class="line error-line">
-        bash: cd: <span id="path-display">/unknown-path</span>: No such file or directory
-      </div>
-    </div>
-
-    <div class="terminal-block">
-      <div class="line comment"># exit code: 404</div>
-      <div class="line comment"># This route doesn't exist. Unlike your rank, which does.</div>
-    </div>
-
-    <hr class="divider" />
-
-    <div class="terminal-block">
-      <div class="line">
-        <span class="prompt">guest@codepvg</span><span class="prompt-sym">:~$</span>
-        <span class="cmd"> ls /valid-routes</span>
-      </div>
-      <div class="line" style="padding-left: 1.2rem;">
-        <span class="highlight"><a href="/leaderboard">leaderboard/</a></span>
-        &nbsp;&nbsp;
-        <span class="highlight"><a href="/registration">registration/</a></span>
-        &nbsp;&nbsp;
-        <span class="highlight"><a href="/about">about/</a></span>
-      </div>
-    </div>
-
-    <div class="line">
-      <span class="prompt">guest@codepvg</span><span class="prompt-sym">:~$</span>
-      <span class="cursor"
-        style="width:9px; height:1rem; background:var(--green); display:inline-block; vertical-align:middle; margin-left:6px; animation: blink 1s step-end infinite;"></span>
-    </div>
-
-    <div class="nav-links">
-      <a href="/leaderboard" class="btn btn-primary">view_leaderboard</a>
-      <a href="/registration" class="btn btn-secondary">register_now</a>
-    </div>
-
-  </div>
-
-  <script>
-    // Inject actual bad path
-    const p = window.location.pathname;
-    document.getElementById('cd-line').textContent = ' cd ' + p;
-    document.getElementById('path-display').textContent = p;
-
-    // Matrix rain
-    const canvas = document.getElementById('matrix');
-    const ctx = canvas.getContext('2d');
-
-    function resize() {
-      canvas.width = window.innerWidth;
-      canvas.height = window.innerHeight;
-    }
-    resize();
-    window.addEventListener('resize', resize);
-
-    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#$%^&*()アイウエオカキクケコサシスセソタチツテトナニヌネノ';
-    const fontSize = 14;
-    let cols = Math.floor(canvas.width / fontSize);
-    let drops = Array(cols).fill(1);
-
-    function drawMatrix() {
-      ctx.fillStyle = 'rgba(0, 0, 0, 0.05)';
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-      ctx.fillStyle = '#00ff41';
-      ctx.font = fontSize + 'px Share Tech Mono, monospace';
-
-      cols = Math.floor(canvas.width / fontSize);
-      if (drops.length < cols) drops = drops.concat(Array(cols - drops.length).fill(1));
-
-      for (let i = 0; i < cols; i++) {
-        const char = chars[Math.floor(Math.random() * chars.length)];
-        ctx.fillText(char, i * fontSize, drops[i] * fontSize);
-        if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) drops[i] = 0;
-        drops[i]++;
+          rgba(0, 0, 0, 0.05) 4px
+        );
+        pointer-events: none;
+        z-index: 2;
       }
-    }
+    </style>
+  </head>
 
-    setInterval(drawMatrix, 40);
-  </script>
+  <body>
+    <canvas id="matrix"></canvas>
 
-</body>
+    <div class="panel">
+      <div class="title">404 — Not Found<span class="cursor"></span></div>
+      <div class="subtitle">
+        &gt; route resolution failed. filesystem integrity nominal.
+      </div>
 
+      <hr class="divider" />
+
+      <div class="terminal-block">
+        <div class="line">
+          <span class="prompt">guest@codepvg</span
+          ><span class="prompt-sym">:~$</span>
+          <span class="cmd" id="cd-line"> cd /unknown-path</span>
+        </div>
+        <div class="line error-line">
+          bash: cd: <span id="path-display">/unknown-path</span>: No such file
+          or directory
+        </div>
+      </div>
+
+      <div class="terminal-block">
+        <div class="line comment"># exit code: 404</div>
+        <div class="line comment">
+          # This route doesn't exist. Unlike your rank, which does.
+        </div>
+      </div>
+
+      <hr class="divider" />
+
+      <div class="terminal-block">
+        <div class="line">
+          <span class="prompt">guest@codepvg</span
+          ><span class="prompt-sym">:~$</span>
+          <span class="cmd"> ls /valid-routes</span>
+        </div>
+        <div class="line" style="padding-left: 1.2rem">
+          <span class="highlight"><a href="/leaderboard">leaderboard/</a></span>
+          &nbsp;&nbsp;
+          <span class="highlight"
+            ><a href="/registration">registration/</a></span
+          >
+          &nbsp;&nbsp;
+          <span class="highlight"><a href="/about">about/</a></span>
+        </div>
+      </div>
+
+      <div class="line">
+        <span class="prompt">guest@codepvg</span
+        ><span class="prompt-sym">:~$</span>
+        <span
+          class="cursor"
+          style="
+            width: 9px;
+            height: 1rem;
+            background: var(--green);
+            display: inline-block;
+            vertical-align: middle;
+            margin-left: 6px;
+            animation: blink 1s step-end infinite;
+          "
+        ></span>
+      </div>
+
+      <div class="nav-links">
+        <a href="/leaderboard" class="btn btn-primary">view_leaderboard</a>
+        <a href="/registration" class="btn btn-secondary">register_now</a>
+      </div>
+    </div>
+
+    <script>
+      // Inject actual bad path
+      const p = window.location.pathname;
+      document.getElementById("cd-line").textContent = " cd " + p;
+      document.getElementById("path-display").textContent = p;
+
+      // Matrix rain
+      const canvas = document.getElementById("matrix");
+      const ctx = canvas.getContext("2d");
+
+      function resize() {
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight;
+      }
+      resize();
+      window.addEventListener("resize", resize);
+
+      const chars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#$%^&*()アイウエオカキクケコサシスセソタチツテトナニヌネノ";
+      const fontSize = 14;
+      let cols = Math.floor(canvas.width / fontSize);
+      let drops = Array(cols).fill(1);
+
+      function drawMatrix() {
+        ctx.fillStyle = "rgba(0, 0, 0, 0.05)";
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        ctx.fillStyle = "#00ff41";
+        ctx.font = fontSize + "px Share Tech Mono, monospace";
+
+        cols = Math.floor(canvas.width / fontSize);
+        if (drops.length < cols)
+          drops = drops.concat(Array(cols - drops.length).fill(1));
+
+        for (let i = 0; i < cols; i++) {
+          const char = chars[Math.floor(Math.random() * chars.length)];
+          ctx.fillText(char, i * fontSize, drops[i] * fontSize);
+          if (drops[i] * fontSize > canvas.height && Math.random() > 0.975)
+            drops[i] = 0;
+          drops[i]++;
+        }
+      }
+
+      setInterval(drawMatrix, 40);
+    </script>
+  </body>
 </html>

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -1,26 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>404 — Not Found | CodePVG</title>
+  <link rel="icon" type="image/png" href="assets/logo.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Space+Mono:wght@400;700&family=Share+Tech+Mono&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles/main.css" />
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
-
-    :root {
-      --green: #00ff41;
-      --green-dim: #00cc33;
-      --green-dark: #003b00;
-      --green-glow: rgba(0, 255, 65, 0.4);
-      --bg: #0d0d0d;
-      --panel-bg: rgba(0, 10, 0, 0.85);
-      --panel-border: rgba(0, 255, 65, 0.3);
-      --red: #ff4444;
-      --grey: #4a8c4a;
-    }
-
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-
+    /* 404-specific overrides */
     body {
       background: var(--bg);
       color: var(--green);
@@ -36,8 +30,10 @@
     /* Matrix rain canvas */
     #matrix {
       position: fixed;
-      top: 0; left: 0;
-      width: 100%; height: 100%;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
       z-index: 0;
       opacity: 0.18;
     }
@@ -46,13 +42,13 @@
     .panel {
       position: relative;
       z-index: 1;
-      background: var(--panel-bg);
-      border: 1px solid var(--panel-border);
+      background: rgba(0, 10, 0, 0.85);
+      border: 1px solid rgba(0, 255, 65, 0.3);
       border-radius: 4px;
       padding: 2.5rem 3rem;
       max-width: 680px;
       width: 90%;
-      box-shadow: 0 0 40px rgba(0, 255, 65, 0.08), inset 0 0 60px rgba(0,0,0,0.5);
+      box-shadow: 0 0 40px rgba(0, 255, 65, 0.08), inset 0 0 60px rgba(0, 0, 0, 0.5);
     }
 
     /* Title */
@@ -60,7 +56,7 @@
       font-size: 2.4rem;
       font-weight: normal;
       color: var(--green);
-      text-shadow: 0 0 20px var(--green-glow), 0 0 40px var(--green-glow);
+      text-shadow: 0 0 20px rgba(0, 255, 65, 0.4), 0 0 40px rgba(0, 255, 65, 0.4);
       letter-spacing: 2px;
       margin-bottom: 0.4rem;
     }
@@ -76,10 +72,14 @@
       box-shadow: 0 0 8px var(--green);
     }
 
-    @keyframes blink { 50% { opacity: 0; } }
+    @keyframes blink {
+      50% {
+        opacity: 0;
+      }
+    }
 
     .subtitle {
-      color: var(--grey);
+      color: #4a8c4a;
       font-size: 0.85rem;
       margin-bottom: 2rem;
     }
@@ -96,81 +96,78 @@
 
     .prompt {
       color: var(--green);
-      text-shadow: 0 0 8px var(--green-glow);
+      text-shadow: 0 0 8px rgba(0, 255, 65, 0.4);
     }
 
     .prompt-sym {
       color: var(--green-dim);
     }
 
-    .cmd { color: #c9e8c9; }
+    .cmd {
+      color: #c9e8c9;
+    }
 
     .error-line {
       color: var(--red);
       text-shadow: 0 0 8px rgba(255, 68, 68, 0.4);
     }
 
-    .comment { color: var(--grey); }
+    .comment {
+      color: #4a8c4a;
+    }
 
     .highlight {
       color: var(--green);
       font-weight: bold;
-      text-shadow: 0 0 10px var(--green-glow);
+      text-shadow: 0 0 10px rgba(0, 255, 65, 0.4);
+    }
+
+    .highlight a {
+      color: inherit;
+      text-decoration: none;
+      transition: color 0.15s ease;
+    }
+
+    .highlight a:hover {
+      color: #66ffaa;
+      text-shadow: 0 0 12px rgba(0, 255, 65, 0.4);
     }
 
     /* Divider */
     .divider {
       border: none;
-      border-top: 1px solid var(--panel-border);
+      border-top: 1px solid rgba(0, 255, 65, 0.3);
       margin: 1.4rem 0;
     }
 
-    /* Buttons */
+    /* Button area — centered */
     .nav-links {
       display: flex;
       gap: 1.2rem;
       flex-wrap: wrap;
       margin-top: 1.8rem;
-    }
-
-    .nav-links a {
-      color: var(--green);
-      text-decoration: none;
-      border: 1px solid var(--green);
-      padding: 0.5rem 1.4rem;
-      font-family: inherit;
-      font-size: 0.9rem;
-      letter-spacing: 1px;
-      transition: background 0.15s, box-shadow 0.15s, color 0.15s;
-      text-shadow: 0 0 8px var(--green-glow);
-      box-shadow: 0 0 8px rgba(0,255,65,0.1);
-    }
-
-    .nav-links a:hover {
-      background: var(--green);
-      color: #000;
-      text-shadow: none;
-      box-shadow: 0 0 20px var(--green-glow);
+      justify-content: center;
     }
 
     /* Scanline overlay */
     body::after {
       content: '';
       position: fixed;
-      top: 0; left: 0;
-      width: 100%; height: 100%;
-      background: repeating-linear-gradient(
-        0deg,
-        transparent,
-        transparent 2px,
-        rgba(0,0,0,0.05) 2px,
-        rgba(0,0,0,0.05) 4px
-      );
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: repeating-linear-gradient(0deg,
+          transparent,
+          transparent 2px,
+          rgba(0, 0, 0, 0.05) 2px,
+          rgba(0, 0, 0, 0.05) 4px);
       pointer-events: none;
       z-index: 2;
     }
   </style>
 </head>
+
 <body>
 
   <canvas id="matrix"></canvas>
@@ -205,20 +202,23 @@
         <span class="cmd"> ls /valid-routes</span>
       </div>
       <div class="line" style="padding-left: 1.2rem;">
-        <span class="highlight">leaderboard/</span>
+        <span class="highlight"><a href="/leaderboard">leaderboard/</a></span>
         &nbsp;&nbsp;
-        <span class="highlight">registration/</span>
+        <span class="highlight"><a href="/registration">registration/</a></span>
+        &nbsp;&nbsp;
+        <span class="highlight"><a href="/about">about/</a></span>
       </div>
     </div>
 
     <div class="line">
       <span class="prompt">guest@codepvg</span><span class="prompt-sym">:~$</span>
-      <span class="cursor" style="width:9px; height:1rem; background:var(--green); display:inline-block; vertical-align:middle; margin-left:6px; animation: blink 1s step-end infinite;"></span>
+      <span class="cursor"
+        style="width:9px; height:1rem; background:var(--green); display:inline-block; vertical-align:middle; margin-left:6px; animation: blink 1s step-end infinite;"></span>
     </div>
 
     <div class="nav-links">
-      <a href="/leaderboard">[ view_leaderboard ]</a>
-      <a href="/registration">[ register_now ]</a>
+      <a href="/leaderboard" class="btn btn-primary">view_leaderboard</a>
+      <a href="/registration" class="btn btn-secondary">register_now</a>
     </div>
 
   </div>
@@ -267,4 +267,5 @@
   </script>
 
 </body>
+
 </html>

--- a/frontend/404.html
+++ b/frontend/404.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>404 — Not Found | CodePVG</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+
+    :root {
+      --green: #00ff41;
+      --green-dim: #00cc33;
+      --green-dark: #003b00;
+      --green-glow: rgba(0, 255, 65, 0.4);
+      --bg: #0d0d0d;
+      --panel-bg: rgba(0, 10, 0, 0.85);
+      --panel-border: rgba(0, 255, 65, 0.3);
+      --red: #ff4444;
+      --grey: #4a8c4a;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      background: var(--bg);
+      color: var(--green);
+      font-family: 'Share Tech Mono', 'Courier New', monospace;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+      position: relative;
+    }
+
+    /* Matrix rain canvas */
+    #matrix {
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      z-index: 0;
+      opacity: 0.18;
+    }
+
+    /* Main panel */
+    .panel {
+      position: relative;
+      z-index: 1;
+      background: var(--panel-bg);
+      border: 1px solid var(--panel-border);
+      border-radius: 4px;
+      padding: 2.5rem 3rem;
+      max-width: 680px;
+      width: 90%;
+      box-shadow: 0 0 40px rgba(0, 255, 65, 0.08), inset 0 0 60px rgba(0,0,0,0.5);
+    }
+
+    /* Title */
+    .title {
+      font-size: 2.4rem;
+      font-weight: normal;
+      color: var(--green);
+      text-shadow: 0 0 20px var(--green-glow), 0 0 40px var(--green-glow);
+      letter-spacing: 2px;
+      margin-bottom: 0.4rem;
+    }
+
+    .title .cursor {
+      display: inline-block;
+      width: 3px;
+      height: 2.2rem;
+      background: var(--green);
+      vertical-align: middle;
+      margin-left: 4px;
+      animation: blink 1s step-end infinite;
+      box-shadow: 0 0 8px var(--green);
+    }
+
+    @keyframes blink { 50% { opacity: 0; } }
+
+    .subtitle {
+      color: var(--grey);
+      font-size: 0.85rem;
+      margin-bottom: 2rem;
+    }
+
+    /* Terminal lines */
+    .terminal-block {
+      margin-bottom: 1.4rem;
+    }
+
+    .line {
+      line-height: 1.8;
+      font-size: 0.95rem;
+    }
+
+    .prompt {
+      color: var(--green);
+      text-shadow: 0 0 8px var(--green-glow);
+    }
+
+    .prompt-sym {
+      color: var(--green-dim);
+    }
+
+    .cmd { color: #c9e8c9; }
+
+    .error-line {
+      color: var(--red);
+      text-shadow: 0 0 8px rgba(255, 68, 68, 0.4);
+    }
+
+    .comment { color: var(--grey); }
+
+    .highlight {
+      color: var(--green);
+      font-weight: bold;
+      text-shadow: 0 0 10px var(--green-glow);
+    }
+
+    /* Divider */
+    .divider {
+      border: none;
+      border-top: 1px solid var(--panel-border);
+      margin: 1.4rem 0;
+    }
+
+    /* Buttons */
+    .nav-links {
+      display: flex;
+      gap: 1.2rem;
+      flex-wrap: wrap;
+      margin-top: 1.8rem;
+    }
+
+    .nav-links a {
+      color: var(--green);
+      text-decoration: none;
+      border: 1px solid var(--green);
+      padding: 0.5rem 1.4rem;
+      font-family: inherit;
+      font-size: 0.9rem;
+      letter-spacing: 1px;
+      transition: background 0.15s, box-shadow 0.15s, color 0.15s;
+      text-shadow: 0 0 8px var(--green-glow);
+      box-shadow: 0 0 8px rgba(0,255,65,0.1);
+    }
+
+    .nav-links a:hover {
+      background: var(--green);
+      color: #000;
+      text-shadow: none;
+      box-shadow: 0 0 20px var(--green-glow);
+    }
+
+    /* Scanline overlay */
+    body::after {
+      content: '';
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background: repeating-linear-gradient(
+        0deg,
+        transparent,
+        transparent 2px,
+        rgba(0,0,0,0.05) 2px,
+        rgba(0,0,0,0.05) 4px
+      );
+      pointer-events: none;
+      z-index: 2;
+    }
+  </style>
+</head>
+<body>
+
+  <canvas id="matrix"></canvas>
+
+  <div class="panel">
+
+    <div class="title">404 — Not Found<span class="cursor"></span></div>
+    <div class="subtitle">&gt; route resolution failed. filesystem integrity nominal.</div>
+
+    <hr class="divider" />
+
+    <div class="terminal-block">
+      <div class="line">
+        <span class="prompt">guest@codepvg</span><span class="prompt-sym">:~$</span>
+        <span class="cmd" id="cd-line"> cd /unknown-path</span>
+      </div>
+      <div class="line error-line">
+        bash: cd: <span id="path-display">/unknown-path</span>: No such file or directory
+      </div>
+    </div>
+
+    <div class="terminal-block">
+      <div class="line comment"># exit code: 404</div>
+      <div class="line comment"># This route doesn't exist. Unlike your rank, which does.</div>
+    </div>
+
+    <hr class="divider" />
+
+    <div class="terminal-block">
+      <div class="line">
+        <span class="prompt">guest@codepvg</span><span class="prompt-sym">:~$</span>
+        <span class="cmd"> ls /valid-routes</span>
+      </div>
+      <div class="line" style="padding-left: 1.2rem;">
+        <span class="highlight">leaderboard/</span>
+        &nbsp;&nbsp;
+        <span class="highlight">registration/</span>
+      </div>
+    </div>
+
+    <div class="line">
+      <span class="prompt">guest@codepvg</span><span class="prompt-sym">:~$</span>
+      <span class="cursor" style="width:9px; height:1rem; background:var(--green); display:inline-block; vertical-align:middle; margin-left:6px; animation: blink 1s step-end infinite;"></span>
+    </div>
+
+    <div class="nav-links">
+      <a href="/leaderboard">[ view_leaderboard ]</a>
+      <a href="/registration">[ register_now ]</a>
+    </div>
+
+  </div>
+
+  <script>
+    // Inject actual bad path
+    const p = window.location.pathname;
+    document.getElementById('cd-line').textContent = ' cd ' + p;
+    document.getElementById('path-display').textContent = p;
+
+    // Matrix rain
+    const canvas = document.getElementById('matrix');
+    const ctx = canvas.getContext('2d');
+
+    function resize() {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    }
+    resize();
+    window.addEventListener('resize', resize);
+
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#$%^&*()アイウエオカキクケコサシスセソタチツテトナニヌネノ';
+    const fontSize = 14;
+    let cols = Math.floor(canvas.width / fontSize);
+    let drops = Array(cols).fill(1);
+
+    function drawMatrix() {
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.05)';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      ctx.fillStyle = '#00ff41';
+      ctx.font = fontSize + 'px Share Tech Mono, monospace';
+
+      cols = Math.floor(canvas.width / fontSize);
+      if (drops.length < cols) drops = drops.concat(Array(cols - drops.length).fill(1));
+
+      for (let i = 0; i < cols; i++) {
+        const char = chars[Math.floor(Math.random() * chars.length)];
+        ctx.fillText(char, i * fontSize, drops[i] * fontSize);
+        if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) drops[i] = 0;
+        drops[i]++;
+      }
+    }
+
+    setInterval(drawMatrix, 40);
+  </script>
+
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 const express = require("express");
-const path = require('path');
+const path = require("path");
 const cors = require("cors");
 
 const app = express();
@@ -35,7 +35,6 @@ const studentCache = new Map();
 
 app.get("/api/student/:username", async (req, res) => {
   const username = req.params.username;
-
 
   if (studentCache.has(username)) {
     const cached = studentCache.get(username);

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 const express = require("express");
+const path = require('path');
 const cors = require("cors");
-const path = require("path");
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -36,6 +36,7 @@ const studentCache = new Map();
 app.get("/api/student/:username", async (req, res) => {
   const username = req.params.username;
 
+
   if (studentCache.has(username)) {
     const cached = studentCache.get(username);
     if (Date.now() - cached.timestamp < 5 * 60 * 1000) {
@@ -57,8 +58,9 @@ app.get("/api/student/:username", async (req, res) => {
   }
 });
 
+// 404 handler
 app.use((req, res) => {
-  res.status(404).send("Page not found");
+  res.status(404).sendFile(path.join(__dirname, "frontend", "404.html"));
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Description

Adds a custom `404.html` page served by the Express catch-all middleware for all unmatched routes. Previously, undefined routes (e.g. `/xyz`) returned a blank Express fallback with no way back to the app. This fix serves a themed 404 page consistent with the site's terminal/matrix aesthetic.

### Linked Issue

Fixes #97

### Changes Made

- Added catch-all `app.use()` handler at the end of `server.js` that serves `frontend/404.html` with HTTP status 404
- Created `frontend/404.html` with matrix rain background, green terminal palette, dynamic path injection via `window.location.pathname`, and navigation links back to `/leaderboard` and `/registration`

## Type of Change

<!-- Put an 'x' inside the brackets that apply -->

- [ ] Bug fix
- [x] New feature
- [x] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

<!-- Describe how you tested your changes -->

- [x] Tested locally
- [x] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally using Prettier
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

<img width="1680" height="971" alt="Screenshot 2026-06-04 at 1 31 54 PM" src="https://github.com/user-attachments/assets/30707042-f279-4c31-9413-60bce4704956" />
