### PR TITLE
add meta description and Open Graph tags to all pages

### DIFF
--- a/frontend/about.html
+++ b/frontend/about.html
@@ -13,6 +13,13 @@
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="icon" type="image/png" href="assets/logo.png" />
     <script src="js/navbar.js"></script>
+
+    <meta name="description" content="Learn how CodePVG tracks LeetCode progress for PVG students — scoring system, sync schedule, and how to join." />
+    <meta property="og:title" content="About — CodePVG" />
+    <meta property="og:description" content="Learn how CodePVG tracks LeetCode progress for PVG students — scoring system, sync schedule, and how to join." />
+    <meta property="og:url" content="https://codepvg.onrender.com/about" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />
   </head>
   <body>
     <canvas id="matrix-canvas"></canvas>

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -14,12 +14,21 @@
     <link rel="icon" type="image/png" href="assets/logo.png" />
     <script src="js/navbar.js"></script>
 
-    <meta name="description" content="Learn how CodePVG tracks LeetCode progress for PVG students — scoring system, sync schedule, and how to join." />
+    <meta
+      name="description"
+      content="Learn how CodePVG tracks LeetCode progress for PVG students — scoring system, sync schedule, and how to join."
+    />
     <meta property="og:title" content="About — CodePVG" />
-    <meta property="og:description" content="Learn how CodePVG tracks LeetCode progress for PVG students — scoring system, sync schedule, and how to join." />
+    <meta
+      property="og:description"
+      content="Learn how CodePVG tracks LeetCode progress for PVG students — scoring system, sync schedule, and how to join."
+    />
     <meta property="og:url" content="https://codepvg.onrender.com/about" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />
+    <meta
+      property="og:image"
+      content="https://codepvg.onrender.com/assets/logo.png"
+    />
     <meta property="og:site_name" content="CodePVG" />
   </head>
 

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -20,6 +20,7 @@
     <meta property="og:url" content="https://codepvg.onrender.com/about" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />
+    <meta property="og:site_name" content="CodePVG" />
   </head>
 
   <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,6 +12,12 @@
     />
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="icon" type="image/png" href="assets/logo.png" />
+    <meta name="description" content="An open leaderboard for PVG students grinding LeetCode. Track your daily, weekly, and overall progress — ranked by difficulty-weighted score." />
+    <meta property="og:title" content="CodePVG — LeetCode Leaderboard" />
+    <meta property="og:description" content="Track your LeetCode progress and compete with PVG peers. Ranked by problem difficulty. Updated every morning." />
+    <meta property="og:url" content="https://codepvg.onrender.com/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />
   </head>
 
   <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,7 @@
     />
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="icon" type="image/png" href="assets/logo.png" />
-    <meta name="description" content="An open leaderboard for PVG students grinding LeetCode. Track your daily, weekly, and overall progress — ranked by difficulty-weighted score." />
+    <meta name="description" content="An open leaderboard for PVG students grinding LeetCode. Track your daily, weekly, monthly and overall progress — ranked by difficulty-weighted score." />
     <meta property="og:title" content="CodePVG — LeetCode Leaderboard" />
     <meta property="og:description" content="Track your LeetCode progress and compete with PVG peers. Ranked by problem difficulty. Updated every morning." />
     <meta property="og:url" content="https://codepvg.onrender.com/" />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,7 +14,7 @@
     <link rel="icon" type="image/png" href="assets/logo.png" />
     <meta name="description" content="An open leaderboard for PVG students grinding LeetCode. Track your daily, weekly, monthly and overall progress — ranked by difficulty-weighted score." />
     <meta property="og:title" content="CodePVG — LeetCode Leaderboard" />
-    <meta property="og:description" content="Track your LeetCode progress and compete with PVG peers. Ranked by problem difficulty. Updated every morning." />
+    <meta property="og:description" content="Track your LeetCode progress and compete with PVG peers. Ranked by problem difficulty. Updated every 5 minutes." />
     <meta property="og:url" content="https://codepvg.onrender.com/" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,12 +12,21 @@
     />
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="icon" type="image/png" href="assets/logo.png" />
-    <meta name="description" content="An open leaderboard for PVG students grinding LeetCode. Track your daily, weekly, monthly and overall progress — ranked by difficulty-weighted score." />
+    <meta
+      name="description"
+      content="An open leaderboard for PVG students grinding LeetCode. Track your daily, weekly, monthly and overall progress — ranked by difficulty-weighted score."
+    />
     <meta property="og:title" content="CodePVG — LeetCode Leaderboard" />
-    <meta property="og:description" content="Track your LeetCode progress and compete with PVG peers. Ranked by problem difficulty. Updated every 5 minutes." />
+    <meta
+      property="og:description"
+      content="Track your LeetCode progress and compete with PVG peers. Ranked by problem difficulty. Updated every 5 minutes."
+    />
     <meta property="og:url" content="https://codepvg.onrender.com/" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />
+    <meta
+      property="og:image"
+      content="https://codepvg.onrender.com/assets/logo.png"
+    />
     <meta property="og:site_name" content="CodePVG" />
   </head>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,6 +18,7 @@
     <meta property="og:url" content="https://codepvg.onrender.com/" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />
+    <meta property="og:site_name" content="CodePVG" />
   </head>
 
   <body>

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -16,7 +16,7 @@
 
     <meta name="description" content="Live LeetCode leaderboard for PVG students. See overall, monthly, weekly, and daily rankings scored by problem difficulty." />
     <meta property="og:title" content="Leaderboard — CodePVG" />
-    <meta property="og:description" content="Live LeetCode leaderboard for PVG students. Scored by problem difficulty, updated daily." />
+    <meta property="og:description" content="Live LeetCode leaderboard for PVG students. Scored by problem difficulty, updated every 5 minutes." />
     <meta property="og:url" content="https://codepvg.onrender.com/leaderboard" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -13,6 +13,13 @@
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="icon" type="image/png" href="assets/logo.png" />
     <script src="js/navbar.js"></script>
+
+    <meta name="description" content="Live LeetCode leaderboard for PVG students. See overall, monthly, weekly, and daily rankings scored by problem difficulty." />
+    <meta property="og:title" content="Leaderboard — CodePVG" />
+    <meta property="og:description" content="Live LeetCode leaderboard for PVG students. Scored by problem difficulty, updated daily." />
+    <meta property="og:url" content="https://codepvg.onrender.com/leaderboard" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />
   </head>
 
   <body>

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -13,6 +13,10 @@
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="icon" type="image/png" href="assets/logo.png" />
     <script src="js/navbar.js"></script>
+    <script src="js/leaderboard/tooltip.js"></script>
+    <script src="js/leaderboard/render.js"></script>
+    <script src="js/leaderboard/pagination.js"></script>
+    <script src="js/leaderboard/search.js"></script>
 
     <meta name="description" content="Live LeetCode leaderboard for PVG students. See overall, monthly, weekly, and daily rankings scored by problem difficulty." />
     <meta property="og:title" content="Leaderboard — CodePVG" />
@@ -20,10 +24,7 @@
     <meta property="og:url" content="https://codepvg.onrender.com/leaderboard" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />
-    <script src="js/leaderboard/tooltip.js"></script>
-    <script src="js/leaderboard/render.js"></script>
-    <script src="js/leaderboard/pagination.js"></script>
-    <script src="js/leaderboard/search.js"></script>
+    <meta property="og:site_name" content="CodePVG" />
   </head>
 
   <body>

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -18,12 +18,24 @@
     <script src="js/leaderboard/pagination.js"></script>
     <script src="js/leaderboard/search.js"></script>
 
-    <meta name="description" content="Live LeetCode leaderboard for PVG students. See overall, monthly, weekly, and daily rankings scored by problem difficulty." />
+    <meta
+      name="description"
+      content="Live LeetCode leaderboard for PVG students. See overall, monthly, weekly, and daily rankings scored by problem difficulty."
+    />
     <meta property="og:title" content="Leaderboard — CodePVG" />
-    <meta property="og:description" content="Live LeetCode leaderboard for PVG students. Scored by problem difficulty, updated every 5 minutes." />
-    <meta property="og:url" content="https://codepvg.onrender.com/leaderboard" />
+    <meta
+      property="og:description"
+      content="Live LeetCode leaderboard for PVG students. Scored by problem difficulty, updated every 5 minutes."
+    />
+    <meta
+      property="og:url"
+      content="https://codepvg.onrender.com/leaderboard"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />
+    <meta
+      property="og:image"
+      content="https://codepvg.onrender.com/assets/logo.png"
+    />
     <meta property="og:site_name" content="CodePVG" />
   </head>
 

--- a/frontend/registration.html
+++ b/frontend/registration.html
@@ -14,12 +14,24 @@
     <link rel="icon" type="image/png" href="assets/logo.png" />
     <script src="js/navbar.js"></script>
 
-    <meta name="description" content="Register your LeetCode username to join the CodePVG leaderboard and start tracking your progress." />
+    <meta
+      name="description"
+      content="Register your LeetCode username to join the CodePVG leaderboard and start tracking your progress."
+    />
     <meta property="og:title" content="Join the Leaderboard — CodePVG" />
-    <meta property="og:description" content="Register your LeetCode username and compete with PVG students. Live leaderboard updates every 5 minutes with difficulty-weighted scoring." />
-    <meta property="og:url" content="https://codepvg.onrender.com/registration" />
+    <meta
+      property="og:description"
+      content="Register your LeetCode username and compete with PVG students. Live leaderboard updates every 5 minutes with difficulty-weighted scoring."
+    />
+    <meta
+      property="og:url"
+      content="https://codepvg.onrender.com/registration"
+    />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />
+    <meta
+      property="og:image"
+      content="https://codepvg.onrender.com/assets/logo.png"
+    />
     <meta property="og:site_name" content="CodePVG" />
   </head>
 

--- a/frontend/registration.html
+++ b/frontend/registration.html
@@ -13,6 +13,13 @@
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="icon" type="image/png" href="assets/logo.png" />
     <script src="js/navbar.js"></script>
+
+    <meta name="description" content="Register your LeetCode username to join the CodePVG leaderboard and start tracking your progress." />
+    <meta property="og:title" content="Join the Leaderboard — CodePVG" />
+    <meta property="og:description" content="Register your LeetCode username and compete with PVG students. Daily sync, difficulty-weighted scoring." />
+    <meta property="og:url" content="https://codepvg.onrender.com/registration" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />
   </head>
 
   <body>

--- a/frontend/registration.html
+++ b/frontend/registration.html
@@ -20,6 +20,7 @@
     <meta property="og:url" content="https://codepvg.onrender.com/registration" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />
+    <meta property="og:site_name" content="CodePVG" />
   </head>
 
   <body>

--- a/frontend/registration.html
+++ b/frontend/registration.html
@@ -16,7 +16,7 @@
 
     <meta name="description" content="Register your LeetCode username to join the CodePVG leaderboard and start tracking your progress." />
     <meta property="og:title" content="Join the Leaderboard — CodePVG" />
-    <meta property="og:description" content="Register your LeetCode username and compete with PVG students. Daily sync, difficulty-weighted scoring." />
+    <meta property="og:description" content="Register your LeetCode username and compete with PVG students. Live leaderboard updates every 5 minutes with difficulty-weighted scoring." />
     <meta property="og:url" content="https://codepvg.onrender.com/registration" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://codepvg.onrender.com/assets/logo.png" />


### PR DESCRIPTION
## Description

All pages had no `<meta name="description">` or Open Graph tags, causing blank preview cards when links are shared on WhatsApp or LinkedIn, and Google search snippets falling back to raw on-page text like `SYS_STATUS: LAST SYNC __AWAITING_UPLINK__`.

This PR adds proper meta and OG tags to all four pages using the existing `assets/logo.png` as the preview image.

### Linked Issue

Fixes #98 

### Changes Made

- Added `meta name="description"`, `og:title`, `og:description`, `og:url`, `og:type`, and `og:image` to `index.html`, `leaderboard.html`, `registration.html`, and `about.html`

## Type of Change

<!-- Put an 'x' inside the brackets that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor

## Testing

<!-- Describe how you tested your changes -->

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

Deployed fork to Render and verified all pages on metatags.io — Google, Twitter/X, Facebook, and LinkedIn preview cards render correctly with title, description, and logo.

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally using Prettier
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

<img width="905" height="973" alt="image" src="https://github.com/user-attachments/assets/3a72bf84-40d9-4955-a645-3bff8704c615" />
<img width="811" height="1009" alt="image" src="https://github.com/user-attachments/assets/39115299-8c88-4c41-979f-ab1d4402f02b" />
<img width="830" height="720" alt="image" src="https://github.com/user-attachments/assets/bacfc97d-abe2-4604-a3f0-4294982800bb" />
<img width="810" height="679" alt="image" src="https://github.com/user-attachments/assets/cb256d13-263e-4733-8a92-c8292039a82a" />
<img width="797" height="618" alt="image" src="https://github.com/user-attachments/assets/23157d1b-cb9a-49b7-979c-b62c980d56e0" />
