### PR TITLE
fix: add missing let/const declarations and strict mode to sync-leaderboard.js (#60)

### DIFF
--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const axios = require("axios");
 const fs = require("fs");
 const path = require("path");
@@ -99,11 +101,11 @@ function getFileName(daysAgo) {
     process.exit(1);
   }
 
-  dailyData = JSON.parse(JSON.stringify(overallData));
+  let dailyData = JSON.parse(JSON.stringify(overallData));
   console.log(" ");
   console.log("Loading previous day's file...");
   const previousDayFilepath = path.join(DATA_DIR, "daily", getFileName(1));
-  previousData = [];
+  let previousData = [];
   try {
     const rawData = fs.readFileSync(previousDayFilepath, "utf8");
     previousData = JSON.parse(rawData);
@@ -152,7 +154,7 @@ function getFileName(daysAgo) {
     process.exit(1);
   }
 
-  weeklyData = JSON.parse(JSON.stringify(overallData));
+  let weeklyData = JSON.parse(JSON.stringify(overallData));
   console.log(" ");
   console.log("Loading previous week's file...");
   const previousWeekFilepath = path.join(DATA_DIR, "daily", getFileName(7));
@@ -211,7 +213,7 @@ function getFileName(daysAgo) {
     process.exit(1);
   }
 
-  monthlyData = JSON.parse(JSON.stringify(overallData));
+  let monthlyData = JSON.parse(JSON.stringify(overallData));
   console.log(" ");
   console.log("Loading previous month's file...");
   const previousMonthFilepath = path.join(DATA_DIR, "daily", getFileName(30));


### PR DESCRIPTION
## Description

Adds missing `"use strict"` directive and `let` declarations to variables in `scripts/sync-leaderboard.js` that were previously assigned without declaration, leaking to the global scope. Without strict mode, these implicit globals can cause silent data corruption (wrong scores, swapped rankings, duplicate entries) when the three parallel processing blocks (daily/weekly/monthly) share state — and no error is thrown.

### Linked Issue

Fixes #60

### Changes Made

- Added `"use strict";` at the top of the file — makes accidental global assignment an immediate runtime error instead of silent corruption
- Added `let` to `dailyData` declaration (line 104)
- Added `let` to `previousData` declaration (line 108)
- Added `let` to `weeklyData` declaration (line 157)
- Added `let` to `monthlyData` declaration (line 216)

Subsequent reassignments of `previousData` (lines 161, 220) remain as-is — `let` allows reassignment within the same function scope.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

**Verification performed:**
- `node --check scripts/sync-leaderboard.js` — Syntax OK
- `npx prettier --check "frontend/**/*.{html,css,js}" "scripts/**/*.js" "server.js"` — All files pass

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally using Prettier
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

N/A — Backend-only change with no UI impact.