### PR TITLE
fix: prevent process.exit(1) on single user API failure (#61)

### DIFF
--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -4,15 +4,15 @@ const path = require("path");
 
 async function fetchData(url) {
   try {
-    const res = await axios.get(url);
+    const res = await axios.get(url, { timeout: 15000 });
     return {
       easySolved: res.data.easySolved || 0,
       mediumSolved: res.data.mediumSolved || 0,
       hardSolved: res.data.hardSolved || 0,
     };
   } catch (err) {
-    console.error("API failed to respond: ", err.message);
-    process.exit(1);
+    console.error(`API failed for ${url}: ${err.message}`);
+    return null;
   }
 }
 
@@ -53,6 +53,10 @@ function getFileName(daysAgo) {
   console.log("Starting daily fetch...");
   for (const user of users) {
     const data = await fetchData(baseUrl + user.id);
+    if (!data) {
+      console.log(`${user.name}: skipped (API error)`);
+      continue;
+    }
     const score = data.easySolved + data.mediumSolved * 3 + data.hardSolved * 5;
     console.log(`${user.name}:`, data);
     overallData.push({


### PR DESCRIPTION
## Description

Prevents `process.exit(1)` when a single user's LeetCode API call fails. Previously, one transient API failure would kill the entire sync cycle — losing all previously fetched data for other users. Now, failed users are logged and skipped, and syncing continues for the remaining users.

Additionally adds a 15-second axios timeout (default is `0` = infinite) to prevent a hanging request from silently destroying the entire 6-hour CI run.

### Linked Issue

Fixes #61

### Changes Made

- Added `{ timeout: 15000 }` to `axios.get()` call — prevents infinite hangs on unresponsive API
- Changed `process.exit(1)` to `return null` on API failure — keeps the process alive
- Improved error message to include the failing URL — easier debugging
- Added null check in the user loop with `continue` — skips failed users gracefully

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

**Verification performed:**
- `node --check scripts/sync-leaderboard.js` — Syntax OK
- `npx prettier --check "frontend/**/*.{html,css,js}" "scripts/**/*.js" "server.js"` — All files pass

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally using Prettier
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

N/A — Backend-only change with no UI impact.