### PR TITLE
feat: add custom terminal-themed 404 page

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>404 - Page Not Found</title>
+  <style>
+    body {
+      background: #0d1117;
+      color: #58a6ff;
+      font-family: monospace;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+    }
+
+    .terminal {
+      max-width: 700px;
+      padding: 20px;
+    }
+
+    a {
+      color: #7ee787;
+      text-decoration: none;
+      display: block;
+      margin-top: 10px;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <div class="terminal">
+    <p>guest@codepvg:~$ cd /that-page</p>
+    <p>bash: /that-page: No such file or directory</p>
+
+    <br>
+
+    <p>404: Route not found.</p>
+    <p>This route doesn't exist. Unlike your rank, which does.</p>
+
+    <a href="/leaderboard">→ Leaderboard</a>
+    <a href="/registration">→ Registration</a>
+  </div>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -144,3 +144,10 @@ app.use((req, res) => {
 app.listen(PORT, () => {
   console.log(`Server running at http://localhost:${PORT}`);
 });
+
+// Must be last route
+app.use((req, res) => {
+  res
+    .status(404)
+    .sendFile(path.join(__dirname, "frontend", "404.html"));
+});


### PR DESCRIPTION
## Description

Added a custom terminal-themed 404 page for all unmatched routes to improve user experience when navigating to invalid URLs.

### Linked Issue

Fixes #764

### Changes Made

* Added a custom `404.html` page matching the terminal/CLI aesthetic of the website.
* Added an Express catch-all route to serve the custom 404 page for undefined routes.
* Added clear navigation links back to the Leaderboard and Registration pages.
* Improved UX by replacing the default browser/Express 404 response.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [x] UI/Visual update
* [ ] Documentation update
* [ ] Refactor

## Testing

* [x] Tested locally
* [ ] Tested on mobile viewport (if applicable)
* [x] No console errors introduced

## Checklist

* [x] My code follows the project's coding style
* [x] I have formatted my code locally by running `npx prettier --write .` before submitting
* [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings or errors
* [ ] I have updated documentation if required
* [x] I have linked the relevant issue

## Screenshots / Screen Recording

<img width="1918" height="903" alt="Screenshot 2026-06-08 191029" src="https://github.com/user-attachments/assets/9aa6ce79-900d-40d5-a500-f39cdf5251b3" />

