### PR TITLE
Fix tooltip toggle and caret rotation issue

### DIFF
--- a/frontend/js/leaderboard/render.js
+++ b/frontend/js/leaderboard/render.js
@@ -1,3 +1,18 @@
+document.addEventListener("click", (e) => {
+  const scoreEl = e.target.closest(".mobile-score");
+  if (scoreEl) {
+    if (scoreEl.classList.contains("active")) {
+      scoreEl.classList.remove("active");
+    } else {
+      document.querySelectorAll(".mobile-score.active")
+        .forEach(el => el.classList.remove("active"));
+      scoreEl.classList.add("active");
+    }
+    return;
+  }
+  document.querySelectorAll(".mobile-score.active")
+    .forEach(el => el.classList.remove("active"));
+});
 // Creates a rank change DOM element (safe — values are internally generated)
 function createRankChangeElement(rankChange) {
   if (!rankChange) return null;
@@ -132,28 +147,30 @@ function renderLeaderboardRow(user, rank) {
   row.appendChild(totalDiv);
 
   // Score with tooltip — all content is numeric or hardcoded labels
-  const scoreDiv = document.createElement("div");
-  scoreDiv.className = "mobile-score tooltip-score";
-  const scoreSpan = document.createElement("span");
-  scoreSpan.textContent = user.score;
-  scoreDiv.appendChild(scoreSpan);
-  const caretSpan = document.createElement("span");
-  caretSpan.className = "score-caret";
-  scoreDiv.appendChild(caretSpan);
-  scoreDiv.appendChild(
-    buildScoreTooltip(
-      user,
-      easyPoints,
-      mediumPoints,
-      hardPoints,
-      easyScore,
-      mediumScore,
-      hardScore,
-    ),
-  );
-  row.appendChild(scoreDiv);
+const scoreDiv = document.createElement("div");
+scoreDiv.className = "mobile-score tooltip-score";
 
-  return row;
+const scoreSpan = document.createElement("span");
+scoreSpan.textContent = user.score;
+scoreDiv.appendChild(scoreSpan);
+
+const caretSpan = document.createElement("span");
+caretSpan.className = "score-caret";
+scoreDiv.appendChild(caretSpan);
+
+scoreDiv.appendChild(
+  buildScoreTooltip(
+    user,
+    easyPoints,
+    mediumPoints,
+    hardPoints,
+    easyScore,
+    mediumScore,
+    hardScore,
+  )
+);
+row.appendChild(scoreDiv);
+return row;
 }
 
 function renderMobileCard(user, rank) {
@@ -178,24 +195,27 @@ function renderMobileCard(user, rank) {
   cardHeader.appendChild(mobileRank);
 
   const mobileScore = document.createElement("div");
-  mobileScore.className = "mobile-score tooltip-score";
-  const mobileScoreSpan = document.createElement("span");
-  mobileScoreSpan.textContent = user.score;
-  mobileScore.appendChild(mobileScoreSpan);
-  const mobileCaretSpan = document.createElement("span");
-  mobileCaretSpan.className = "score-caret";
-  mobileScore.appendChild(mobileCaretSpan);
-  mobileScore.appendChild(
-    buildScoreTooltip(
-      user,
-      easyPoints,
-      mediumPoints,
-      hardPoints,
-      easyScore,
-      mediumScore,
-      hardScore,
-    ),
-  );
+mobileScore.className = "mobile-score tooltip-score";
+
+const mobileScoreSpan = document.createElement("span");
+mobileScoreSpan.textContent = user.score;
+mobileScore.appendChild(mobileScoreSpan);
+
+const mobileCaretSpan = document.createElement("span");
+mobileCaretSpan.className = "score-caret";
+mobileScore.appendChild(mobileCaretSpan);
+
+mobileScore.appendChild(
+  buildScoreTooltip(
+    user,
+    easyPoints,
+    mediumPoints,
+    hardPoints,
+    easyScore,
+    mediumScore,
+    hardScore,
+  ),
+);
   cardHeader.appendChild(mobileScore);
 
   card.appendChild(cardHeader);

--- a/frontend/js/leaderboard/render.js
+++ b/frontend/js/leaderboard/render.js
@@ -1,5 +1,5 @@
 document.addEventListener("click", (e) => {
-  if (window.innerWidth > 768) return; // desktop uses hover
+if (window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
 
   const scoreEl = e.target.closest(".mobile-score");
 

--- a/frontend/js/leaderboard/render.js
+++ b/frontend/js/leaderboard/render.js
@@ -1,16 +1,25 @@
 document.addEventListener("click", (e) => {
+  if (window.innerWidth > 768) return; // desktop uses hover
+
   const scoreEl = e.target.closest(".mobile-score");
+
   if (scoreEl) {
+    e.preventDefault();
+
     if (scoreEl.classList.contains("active")) {
       scoreEl.classList.remove("active");
     } else {
-      document.querySelectorAll(".mobile-score.active")
+      document
+        .querySelectorAll(".mobile-score.active")
         .forEach(el => el.classList.remove("active"));
+
       scoreEl.classList.add("active");
     }
     return;
   }
-  document.querySelectorAll(".mobile-score.active")
+
+  document
+    .querySelectorAll(".mobile-score.active")
     .forEach(el => el.classList.remove("active"));
 });
 // Creates a rank change DOM element (safe — values are internally generated)

--- a/frontend/js/leaderboard/render.js
+++ b/frontend/js/leaderboard/render.js
@@ -11,7 +11,7 @@ document.addEventListener("click", (e) => {
     } else {
       document
         .querySelectorAll(".mobile-score.active")
-        .forEach(el => el.classList.remove("active"));
+        .forEach((el) => el.classList.remove("active"));
 
       scoreEl.classList.add("active");
     }
@@ -20,7 +20,7 @@ document.addEventListener("click", (e) => {
 
   document
     .querySelectorAll(".mobile-score.active")
-    .forEach(el => el.classList.remove("active"));
+    .forEach((el) => el.classList.remove("active"));
 });
 // Creates a rank change DOM element (safe — values are internally generated)
 function createRankChangeElement(rankChange) {
@@ -156,30 +156,30 @@ function renderLeaderboardRow(user, rank) {
   row.appendChild(totalDiv);
 
   // Score with tooltip — all content is numeric or hardcoded labels
-const scoreDiv = document.createElement("div");
-scoreDiv.className = "mobile-score tooltip-score";
+  const scoreDiv = document.createElement("div");
+  scoreDiv.className = "mobile-score tooltip-score";
 
-const scoreSpan = document.createElement("span");
-scoreSpan.textContent = user.score;
-scoreDiv.appendChild(scoreSpan);
+  const scoreSpan = document.createElement("span");
+  scoreSpan.textContent = user.score;
+  scoreDiv.appendChild(scoreSpan);
 
-const caretSpan = document.createElement("span");
-caretSpan.className = "score-caret";
-scoreDiv.appendChild(caretSpan);
+  const caretSpan = document.createElement("span");
+  caretSpan.className = "score-caret";
+  scoreDiv.appendChild(caretSpan);
 
-scoreDiv.appendChild(
-  buildScoreTooltip(
-    user,
-    easyPoints,
-    mediumPoints,
-    hardPoints,
-    easyScore,
-    mediumScore,
-    hardScore,
-  )
-);
-row.appendChild(scoreDiv);
-return row;
+  scoreDiv.appendChild(
+    buildScoreTooltip(
+      user,
+      easyPoints,
+      mediumPoints,
+      hardPoints,
+      easyScore,
+      mediumScore,
+      hardScore,
+    ),
+  );
+  row.appendChild(scoreDiv);
+  return row;
 }
 
 function renderMobileCard(user, rank) {
@@ -204,27 +204,27 @@ function renderMobileCard(user, rank) {
   cardHeader.appendChild(mobileRank);
 
   const mobileScore = document.createElement("div");
-mobileScore.className = "mobile-score tooltip-score";
+  mobileScore.className = "mobile-score tooltip-score";
 
-const mobileScoreSpan = document.createElement("span");
-mobileScoreSpan.textContent = user.score;
-mobileScore.appendChild(mobileScoreSpan);
+  const mobileScoreSpan = document.createElement("span");
+  mobileScoreSpan.textContent = user.score;
+  mobileScore.appendChild(mobileScoreSpan);
 
-const mobileCaretSpan = document.createElement("span");
-mobileCaretSpan.className = "score-caret";
-mobileScore.appendChild(mobileCaretSpan);
+  const mobileCaretSpan = document.createElement("span");
+  mobileCaretSpan.className = "score-caret";
+  mobileScore.appendChild(mobileCaretSpan);
 
-mobileScore.appendChild(
-  buildScoreTooltip(
-    user,
-    easyPoints,
-    mediumPoints,
-    hardPoints,
-    easyScore,
-    mediumScore,
-    hardScore,
-  ),
-);
+  mobileScore.appendChild(
+    buildScoreTooltip(
+      user,
+      easyPoints,
+      mediumPoints,
+      hardPoints,
+      easyScore,
+      mediumScore,
+      hardScore,
+    ),
+  );
   cardHeader.appendChild(mobileScore);
 
   card.appendChild(cardHeader);

--- a/frontend/js/leaderboard/render.js
+++ b/frontend/js/leaderboard/render.js
@@ -1,5 +1,5 @@
 document.addEventListener("click", (e) => {
-if (window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
+  if (window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
 
   const scoreEl = e.target.closest(".mobile-score");
 

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -2226,10 +2226,6 @@ body::-webkit-scrollbar-thumb {
   pointer-events: none;
 }
 
-.tooltip-score:hover .score-tooltip {
-  opacity: 1;
-  visibility: visible;
-}
 
 .score-tooltip hr {
   border: none;
@@ -2241,17 +2237,14 @@ body::-webkit-scrollbar-thumb {
   font-size: 0.75rem;
   color: rgba(255, 255, 255, 0.4);
   display: inline-block;
-  transition:
-    transform 0.25s ease,
-    color 0.25s ease;
+  transition: transform 0.25s ease, color 0.25s ease;
+  transform: rotate(0deg);
 }
 
 .score-caret::after {
   content: ">";
 }
-
 .tooltip-score:hover .score-caret {
-  transform: rotate(90deg);
   color: var(--cyan);
 }
 
@@ -2516,4 +2509,15 @@ body::-webkit-scrollbar-thumb {
 
 .rank-neutral {
   color: var(--text-muted);
+}
+
+.tooltip-score.active .score-tooltip {
+  opacity: 1;
+  visibility: visible;
+    pointer-events: auto;
+}
+
+.tooltip-score.active .score-caret {
+  transform: rotate(90deg);
+  color: var(--cyan);
 }

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -1028,7 +1028,7 @@ body::after {
   justify-content: flex-end;
   gap: 6px;
 
-    user-select: none;
+  user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2238,7 +2238,6 @@ body::-webkit-scrollbar-thumb {
   pointer-events: none;
 }
 
-
 .score-tooltip hr {
   border: none;
   border-top: 1px solid rgba(255, 255, 255, 0.15);
@@ -2249,7 +2248,9 @@ body::-webkit-scrollbar-thumb {
   font-size: 0.75rem;
   color: rgba(255, 255, 255, 0.4);
   display: inline-block;
-  transition: transform 0.25s ease, color 0.25s ease;
+  transition:
+    transform 0.25s ease,
+    color 0.25s ease;
   transform: rotate(0deg);
 }
 
@@ -2546,5 +2547,3 @@ body::-webkit-scrollbar-thumb {
 .rank-neutral {
   color: var(--text-muted);
 }
-
-

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -1027,6 +1027,18 @@ body::after {
   align-items: center;
   justify-content: flex-end;
   gap: 6px;
+
+    user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
+}
+.mobile-score span {
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .mobile-name {
@@ -2244,8 +2256,32 @@ body::-webkit-scrollbar-thumb {
 .score-caret::after {
   content: ">";
 }
-.tooltip-score:hover .score-caret {
+@media (hover: hover) and (pointer: fine) {
+  .tooltip-score:hover .score-caret {
+    color: var(--cyan);
+  }
+}
+
+.tooltip-score.active .score-tooltip {
+  opacity: 1;
+  visibility: visible;
+}
+@media (hover: hover) and (pointer: fine) {
+  .tooltip-score:hover .score-tooltip {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+.tooltip-score.active .score-caret {
+  transform: rotate(90deg);
   color: var(--cyan);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .tooltip-score:hover .score-caret {
+    transform: rotate(90deg);
+    color: var(--cyan);
+  }
 }
 
 /* ── Search Bar ── */
@@ -2511,13 +2547,4 @@ body::-webkit-scrollbar-thumb {
   color: var(--text-muted);
 }
 
-.tooltip-score.active .score-tooltip {
-  opacity: 1;
-  visibility: visible;
-    pointer-events: auto;
-}
 
-.tooltip-score.active .score-caret {
-  transform: rotate(90deg);
-  color: var(--cyan);
-}


### PR DESCRIPTION
## Description

Fixed tooltip toggle issue in leaderboard and mobile card views. Previously, tooltip was not closing properly on second click due to conflict between hover-based CSS and JavaScript-controlled active state. Also improved caret rotation behavior for better UX consistency across mobile and desktop.

### Linked Issue

Fixes #127

### Changes Made

- Removed hover-based tooltip visibility conflict
- Made tooltip fully controlled via `.active` class in JavaScript
- Fixed issue where tooltip did not close on second click
- Improved caret rotation sync with tooltip state
- Ensured consistent behavior on mobile and desktop devices
- Cleaned up event handling to avoid duplicate listeners

## Type of Change

- [x] Bug fix
- [x] UI/Visual update


## Testing

- [x] Tested locally
- [x] Tested on mobile viewport (Chrome DevTools)
- [x] Verified tooltip opens and closes correctly
- [x] Verified no console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have linked the relevant issue

##  Screen Recording
Uploading Screen Recording 2026-06-10 000946.mp4…



