### PR TITLE
feat: implement 1224 competition ranking with deterministic tie-breaker at sync layer

### DIFF
--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -257,12 +257,7 @@
 
         const originalData = leaderboardData[activeDatasetType];
 
-        const rankedData = originalData.map((user, index) => ({
-          ...user,
-          originalRank: index + 1,
-        }));
-
-        const filteredData = rankedData.filter((user) => {
+        const filteredData = originalData.filter((user) => {
           if (!currentSearchTerm) return true;
 
           return (
@@ -346,7 +341,10 @@
         }
 
         displayData.forEach((user, index) => {
-          const rank = user.originalRank || index + 1;
+          const rank =
+            user.originalRank !== undefined
+              ? user.originalRank
+              : startIndex + index + 1;
           const row = renderLeaderboardRow(user, rank);
           const card = renderMobileCard(user, rank);
           body.appendChild(row);

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -31,6 +31,26 @@ function getFileName(daysAgo) {
   return `${year}-${month}-${date}-${day}.json`;
 }
 
+
+function assignCompetitionRanks(sortedData) {
+  let currentRank = 1;
+  for (let i = 0; i < sortedData.length; i++) {
+    if (i > 0 && sortedData[i].score < sortedData[i - 1].score) {
+      currentRank = i + 1;
+    }
+    sortedData[i].originalRank = currentRank;
+  }
+}
+
+function stableSortByScore(dataArray) {
+  dataArray.sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    return a.id.localeCompare(b.id); 
+  });
+}
+
 async function getYesterdaySnapshot(filePath) {
   const owner = "codepvg";
   const repo = "leetcode-ranking-data";
@@ -156,7 +176,8 @@ async function computeRankChanges(currentSorted, filename) {
       user.data.easySolved + user.data.mediumSolved + user.data.hardSolved;
   });
   console.log("Sorting collected data...");
-  overallData.sort((a, b) => b.score - a.score);
+  stableSortByScore(overallData);
+  assignCompetitionRanks(overallData);
   console.log("Writing sorted daily data to overall file...");
   const overallFilepath = path.join(DATA_DIR, "overall.json");
   await computeRankChanges(overallData, "overall.json");
@@ -215,8 +236,8 @@ async function computeRankChanges(currentSorted, filename) {
   console.log("");
 
   console.log("Sorting calculated data...");
-  dailyData.sort((a, b) => b.score - a.score);
-
+  stableSortByScore(dailyData);
+  assignCompetitionRanks(dailyData);
   console.log("Writing sorted daily data to daily.json...");
   const dailyFilepath = path.join(DATA_DIR, "daily.json");
   await computeRankChanges(dailyData, "daily.json");
@@ -271,8 +292,8 @@ async function computeRankChanges(currentSorted, filename) {
   console.log("");
 
   console.log("Sorting calculated data...");
-  weeklyData.sort((a, b) => b.score - a.score);
-
+  stableSortByScore(weeklyData);
+  assignCompetitionRanks(weeklyData);
   console.log("Writing sorted weekly data to weekly.json...");
   const weeklyFilepath = path.join(DATA_DIR, "weekly.json");
   await computeRankChanges(weeklyData, "weekly.json");
@@ -331,8 +352,8 @@ async function computeRankChanges(currentSorted, filename) {
   console.log("");
 
   console.log("Sorting calculated data...");
-  monthlyData.sort((a, b) => b.score - a.score);
-
+  stableSortByScore(monthlyData);
+  assignCompetitionRanks(monthlyData);
   console.log("Writing sorted monthly data to monthly.json...");
   const monthlyFilepath = path.join(DATA_DIR, "monthly.json");
   await computeRankChanges(monthlyData, "monthly.json");

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -31,7 +31,6 @@ function getFileName(daysAgo) {
   return `${year}-${month}-${date}-${day}.json`;
 }
 
-
 function assignCompetitionRanks(sortedData) {
   let currentRank = 1;
   for (let i = 0; i < sortedData.length; i++) {
@@ -47,7 +46,7 @@ function stableSortByScore(dataArray) {
     if (b.score !== a.score) {
       return b.score - a.score;
     }
-    return a.id.localeCompare(b.id); 
+    return a.id.localeCompare(b.id);
   });
 }
 


### PR DESCRIPTION
## Description

This PR migrates the leaderboard ranking calculation from the frontend client-side directly into the backend sync layer script. It implements the 1224 competition ranking system natively on the data files before they are written to disk, reducing frontend compute overhead and ensuring data consistency.

### Linked Issue

Fixes #100 

### Changes Made

- **Deterministic Sort (`stableSortByScore`):** Implemented a stable sorting utility that uses user `id` string comparison as a tie-breaker fallback to prevent data files from fluttering across periodic GitHub Actions runs.
- **Competition Ranking (`assignCompetitionRanks`):** Created a dense 1224 competition rank calculator that assigns matching static ranks to tied scores and skips to the exact array offset for trailing items.
- **Frontend Cleanup:** Streamlined the client-side `fetchLeaderboardData()` in `index.html` to instantly display data directly as structured from the backend.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor

## Testing

- [x] Tested locally (Verified logic against raw JSON structures)
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

N/A (Backend logic refactor)
