### PR TITLE
Added Scroll Up Button for small device

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -95,5 +95,6 @@
     <script src="js/boot.js"></script>
     <script src="js/hero_fx.js"></script>
     <script src="js/matrix.js"></script>
+    <script src="js/leaderboard/mobile-scroll-top.js"></script>
   </body>
 </html>

--- a/frontend/js/leaderboard/mobile-scroll-top.js
+++ b/frontend/js/leaderboard/mobile-scroll-top.js
@@ -1,0 +1,22 @@
+const scrollTopBtn = document.getElementById("scrollTopBtn");
+
+function toggleScrollButton() {
+  if (window.innerWidth <= 768 && window.scrollY > 300) {
+    scrollTopBtn.classList.add("show");
+  } else {
+    scrollTopBtn.classList.remove("show");
+  }
+}
+
+window.addEventListener("scroll", toggleScrollButton);
+window.addEventListener("resize", toggleScrollButton);
+
+scrollTopBtn.addEventListener("click", () => {
+  window.scrollTo({
+    top: 0,
+    behavior: "smooth",
+  });
+});
+
+// Initial check
+toggleScrollButton();

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -42,6 +42,10 @@
   <body>
     <canvas id="matrix-canvas"></canvas>
 
+    <button id="scrollTopBtn" aria-label="Scroll to top">
+      ⮝
+    </button>
+
     <main class="page">
       <div class="container">
         <h1 class="page-title">Leaderboard</h1>
@@ -374,5 +378,6 @@
     <script src="js/footer.js"></script>
     <script src="js/matrix.js"></script>
     <script src="js/terminal_ui.js"></script>
+    <script src="js/leaderboard/mobile-scroll-top.js"></script>
   </body>
 </html>

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -2520,3 +2520,43 @@ body::-webkit-scrollbar-thumb {
 .rank-neutral {
   color: var(--text-muted);
 }
+
+#scrollTopBtn {
+  position: fixed;
+  right: 20px;
+  bottom: 90px; /* keep above footer area */
+  width: 42px;
+  height: 42px;
+  border: none;
+  border-radius: 50%;
+  outline: 2px solid var(--green);
+  background: rgba(0, 0, 0, 0.8);
+  color: var(--green);
+  font-size: 20px;
+  cursor: pointer;
+  display: none;
+  z-index: 999;
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
+}
+
+#scrollTopBtn:hover {
+  transform: translateY(-2px);
+}
+
+#scrollTopBtn.show {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-width: 768px) {
+  #scrollTopBtn {
+    width: 38px;
+    height: 38px;
+    font-size: 18px;
+    right: 16px;
+    bottom: 100px; /* extra space from footer on mobile */
+  }
+}


### PR DESCRIPTION
## Description

Added a Scroll-to-Top button on the leaderboard page to improve navigation and user experience. Users can now quickly return to the top of the page after scrolling through the leaderboard.

### Linked Issue

Fixes #89 

### Changes Made

-Added a Scroll-to-Top button to the leaderboard page only for small devices
-Implemented smooth scrolling behavior when the button is clicked.
Configured the button to appear only after the user scrolls down a certain distance.
-Styled the button to match the existing UI design.

## Type of Change

- [ ] Bug fix
- [ x] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [ x] Tested locally
- [ x] Tested on mobile viewport (if applicable)
- [ x] No console errors introduced

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have formatted my code locally by running `npx prettier --write .` before submitting
- [ ] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [ x] I have performed a self-review of my code
- [ x] My changes generate no new warnings or errors
- [ x] I have updated documentation if required
- [x ] I have linked the relevant issue

## Screenshots / Screen Recording
<img width="221" height="489" alt="image" src="https://github.com/user-attachments/assets/5e045c6e-71bd-419d-b46a-9a81948c9c6b" />

