### PR TITLE
Feature: added mobile scroll-to-top button in leaderboard

### DIFF
--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -373,15 +373,19 @@
     </script>
 
     <!-- Scroll to Top button -->
-    <button id="scroll-top-btn" aria-label="Scroll to top">^<br>TOP</button>
+    <button id="scroll-top-btn" aria-label="Scroll to top">^<br />TOP</button>
 
     <script nonce="__NONCE__">
       (function () {
         var btn = document.getElementById("scroll-top-btn");
         var THRESHOLD = 300;
-        window.addEventListener("scroll", function () {
-          btn.classList.toggle("visible", window.scrollY > THRESHOLD);
-        }, { passive: true });
+        window.addEventListener(
+          "scroll",
+          function () {
+            btn.classList.toggle("visible", window.scrollY > THRESHOLD);
+          },
+          { passive: true },
+        );
         btn.addEventListener("click", function () {
           window.scrollTo({ top: 0, behavior: "smooth" });
         });

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -371,6 +371,23 @@
         applyFiltersAndRender();
       }
     </script>
+
+    <!-- Scroll to Top button -->
+    <button id="scroll-top-btn" aria-label="Scroll to top">^<br>TOP</button>
+
+    <script nonce="__NONCE__">
+      (function () {
+        var btn = document.getElementById("scroll-top-btn");
+        var THRESHOLD = 300;
+        window.addEventListener("scroll", function () {
+          btn.classList.toggle("visible", window.scrollY > THRESHOLD);
+        }, { passive: true });
+        btn.addEventListener("click", function () {
+          window.scrollTo({ top: 0, behavior: "smooth" });
+        });
+      })();
+    </script>
+
     <script src="js/footer.js"></script>
     <script src="js/matrix.js"></script>
     <script src="js/terminal_ui.js"></script>

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -2520,3 +2520,48 @@ body::-webkit-scrollbar-thumb {
 .rank-neutral {
   color: var(--text-muted);
 }
+
+/* scroll to top button */
+#scroll-top-btn {
+  display: none; /* hidden on desktop entirely, can be changed if needed */
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.25rem;
+  z-index: 111999;
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+
+  background: transparent;
+  border: 1px solid var(--green);
+  color: var(--green);
+  font-family: "Fira Code", monospace;
+  font-size: 0.75rem;
+  padding: 0.45rem 0.6rem;
+  cursor: pointer;
+  line-height: 1;
+
+  box-shadow: 0 0 8px rgba(0, 229, 255, 0.25),
+              inset 0 0 8px rgba(0, 229, 255, 0.05);
+  text-shadow: 0 0 6px rgba(0, 229, 255, 0.5);
+
+  transition: opacity 0.25s ease, visibility 0.25s ease, box-shadow 0.2s ease;
+}
+
+@media (max-width: 768px) {
+  #scroll-top-btn {
+    display: block;
+  }
+
+  #scroll-top-btn.visible {
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  #scroll-top-btn:active {
+    box-shadow: 0 0 14px rgba(0, 229, 255, 0.55),
+                inset 0 0 10px rgba(0, 229, 255, 0.15);
+    color: #fff;
+  }
+}

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -2663,8 +2663,7 @@ body::-webkit-scrollbar-thumb {
 
   transform: translateY(20px);
 
-  transition: transform 0.3s
-    cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
 
 .changes-modal-overlay.active .changes-card {

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -2541,11 +2541,15 @@ body::-webkit-scrollbar-thumb {
   cursor: pointer;
   line-height: 1;
 
-  box-shadow: 0 0 8px rgba(0, 229, 255, 0.25),
-              inset 0 0 8px rgba(0, 229, 255, 0.05);
+  box-shadow:
+    0 0 8px rgba(0, 229, 255, 0.25),
+    inset 0 0 8px rgba(0, 229, 255, 0.05);
   text-shadow: 0 0 6px rgba(0, 229, 255, 0.5);
 
-  transition: opacity 0.25s ease, visibility 0.25s ease, box-shadow 0.2s ease;
+  transition:
+    opacity 0.25s ease,
+    visibility 0.25s ease,
+    box-shadow 0.2s ease;
 }
 
 @media (max-width: 768px) {
@@ -2560,8 +2564,9 @@ body::-webkit-scrollbar-thumb {
   }
 
   #scroll-top-btn:active {
-    box-shadow: 0 0 14px rgba(0, 229, 255, 0.55),
-                inset 0 0 10px rgba(0, 229, 255, 0.15);
+    box-shadow:
+      0 0 14px rgba(0, 229, 255, 0.55),
+      inset 0 0 10px rgba(0, 229, 255, 0.15);
     color: #fff;
   }
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and what problem it solves. -->

### Linked Issue

Fixes #89

### Changes Made

- Added a button labelled as "TOP" that has a fixed position at the bottom-right corner of the screen. Initially hidden, the button is visible after the user scrolls atleast 300px. On click, the button smoothly returns the user to the top of the Leaderboard.
- The button matches the UI of the Leaderboard.

## Type of Change

<!-- Put an 'x' inside the brackets that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

<!-- Describe how you tested your changes -->

- [x] Tested locally
- [x] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

<img width="420" height="831" alt="image" src="https://github.com/user-attachments/assets/8d8f03de-0950-4f0c-8661-34dff5723d29" />

