### PR TITLE
Make contact information clickable in legal pages

### DIFF
--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -130,9 +130,7 @@
                 <li>
                   <strong>Website</strong> refers to CodePVG LeetCode
                   Leaderboard, accessible from
-                  <a href="https://codepvg.onrender.com">
-                    https://codepvg.onrender.com
-                  </a>
+                  <a href="/"> https://codepvg.onrender.com </a>
                 </li>
                 <li>
                   <strong>You</strong> means the individual accessing or using
@@ -284,19 +282,16 @@
               <ul>
                 <li>
                   Email:
-                  <a href="mailto:jagadishdrp@gmail.com"
+                  <a
+                    href="mailto:jagadishdrp@gmail.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     >jagadishdrp@gmail.com</a
                   >
                 </li>
                 <li>
                   Website:
-                  <a
-                    href="https://codepvg.onrender.com/about"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    https://codepvg.onrender.com/about
-                  </a>
+                  <a href="/about"> https://codepvg.onrender.com/about </a>
                 </li>
               </ul>
             </div>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -129,7 +129,10 @@
                 <li><strong>Service</strong> refers to the Website.</li>
                 <li>
                   <strong>Website</strong> refers to CodePVG LeetCode
-                  Leaderboard, accessible from https://codepvg.onrender.com
+                  Leaderboard, accessible from
+                  <a href="https://codepvg.onrender.com">
+                    https://codepvg.onrender.com
+                  </a>
                 </li>
                 <li>
                   <strong>You</strong> means the individual accessing or using
@@ -279,8 +282,22 @@
               </p>
 
               <ul>
-                <li>Email: jagadishdrp@gmail.com</li>
-                <li>Website: https://codepvg.onrender.com/about</li>
+                <li>
+                  Email:
+                  <a href="mailto:jagadishdrp@gmail.com"
+                    >jagadishdrp@gmail.com</a
+                  >
+                </li>
+                <li>
+                  Website:
+                  <a
+                    href="https://codepvg.onrender.com/about"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    https://codepvg.onrender.com/about
+                  </a>
+                </li>
               </ul>
             </div>
 

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -123,9 +123,7 @@
                 <li>
                   <strong>Website</strong> refers to CodePVG LeetCode
                   Leaderboard, accessible from
-                  <a href="https://codepvg.onrender.com/">
-                    https://codepvg.onrender.com/
-                  </a>
+                  <a href="/"> https://codepvg.onrender.com/ </a>
                 </li>
                 <li>
                   <strong>You</strong> means the individual, company, or legal
@@ -281,19 +279,16 @@
               <ul>
                 <li>
                   Email:
-                  <a href="mailto:jagadishdrp@gmail.com"
+                  <a
+                    href="mailto:jagadishdrp@gmail.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     >jagadishdrp@gmail.com</a
                   >
                 </li>
                 <li>
                   Website:
-                  <a
-                    href="https://codepvg.onrender.com/about"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    https://codepvg.onrender.com/about
-                  </a>
+                  <a href="/about"> https://codepvg.onrender.com/about </a>
                 </li>
               </ul>
             </div>

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -122,7 +122,10 @@
                 </li>
                 <li>
                   <strong>Website</strong> refers to CodePVG LeetCode
-                  Leaderboard, accessible from https://codepvg.onrender.com/
+                  Leaderboard, accessible from
+                  <a href="https://codepvg.onrender.com/">
+                    https://codepvg.onrender.com/
+                  </a>
                 </li>
                 <li>
                   <strong>You</strong> means the individual, company, or legal
@@ -276,8 +279,22 @@
               </p>
 
               <ul>
-                <li>Email: jagadishdrp@gmail.com</li>
-                <li>Website: https://codepvg.onrender.com/about</li>
+                <li>
+                  Email:
+                  <a href="mailto:jagadishdrp@gmail.com"
+                    >jagadishdrp@gmail.com</a
+                  >
+                </li>
+                <li>
+                  Website:
+                  <a
+                    href="https://codepvg.onrender.com/about"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    https://codepvg.onrender.com/about
+                  </a>
+                </li>
               </ul>
             </div>
 


### PR DESCRIPTION
## Description

Converted contact information in the Privacy Policy and Terms pages from plain text to clickable links. This improves usability by allowing users to directly open email clients and navigate to website references.

### Linked Issue

Fixes #152

### Changes Made

* Converted email addresses into clickable `mailto:` links.
* Converted website references into clickable anchor tags.
* Preserved the existing terminal-themed UI styling by using the existing link styles.
* Updated both `frontend/privacy.html` and `frontend/terms.html`.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [x] UI/Visual update
* [ ] Documentation update
* [ ] Refactor

## Testing

* [x] Tested locally
* [ ] Tested on mobile viewport (if applicable)
* [x] No console errors introduced

## Checklist

* [x] My code follows the project's coding style
* [x] I have formatted my code locally by running `npx prettier --write .` before submitting
* [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings or errors
* [ ] I have updated documentation if required
* [x] I have linked the relevant issue

## Screenshots / Screen Recording
<img width="1920" height="1080" alt="Screenshot from 2026-06-13 13-57-41" src="https://github.com/user-attachments/assets/a3fedb59-d249-4cd8-8334-0cfc265ba7b6" />

<img width="1920" height="1080" alt="Screenshot from 2026-06-13 13-57-59" src="https://github.com/user-attachments/assets/067d46a3-a001-4398-8e41-179508c5b290" />

<img width="1920" height="1080" alt="Screenshot from 2026-06-13 13-58-25" src="https://github.com/user-attachments/assets/b2817c15-a88a-4906-b7b2-1e1617739d69" />

<img width="1920" height="1080" alt="Screenshot from 2026-06-13 13-58-39" src="https://github.com/user-attachments/assets/a043b2c4-0749-4e62-bca7-25c3e4f172aa" />

Attached screenshots showing:

* Clickable email links (`mailto:`)
* Clickable website links
* Consistent terminal-themed styling on both Privacy Policy and Terms pages
