### PR TITLE
fix: use originalRank for rank change calculations

### DIFF
--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -97,13 +97,13 @@ async function computeRankChanges(currentSorted, filename) {
   const previousData = await getYesterdaySnapshot(filename);
 
   if (previousData && Array.isArray(previousData)) {
-    previousData.forEach((user, idx) => {
-      previousRanks[user.id] = idx + 1;
+    previousData.forEach((user) => {
+      previousRanks[user.id] = user.originalRank;
     });
   }
 
-  currentSorted.forEach((user, idx) => {
-    const currentRank = idx + 1;
+  currentSorted.forEach((user) => {
+    const currentRank = user.originalRank;
 
     if (previousRanks[user.id] === undefined) {
       user.rankChange = "NEW";
@@ -382,9 +382,9 @@ async function computeRankChanges(currentSorted, filename) {
   try {
     // Build lookup of previous solve counts and ranks
     const previousMap = {};
-    previousOverall.forEach((user, idx) => {
+    previousOverall.forEach((user) => {
       previousMap[user.id] = {
-        rank: idx + 1,
+        rank: user.originalRank,
         totalSolved: user.data.totalSolved || 0,
       };
     });
@@ -394,8 +394,8 @@ async function computeRankChanges(currentSorted, filename) {
     let totalNewSolves = 0;
     let usersWithNewSolves = 0;
 
-    overallData.forEach((user, idx) => {
-      const currentRank = idx + 1;
+    overallData.forEach((user) => {
+      const currentRank = user.originalRank;
       const prev = previousMap[user.id];
 
       if (!prev) {


### PR DESCRIPTION
## Description
This PR fixes incorrect rank movement detection for users with tied scores. Previously, rank changes were calculated using `idx + 1` (array index), which caused tied users to show false rank movements when their array ordering changed during sorting. Now `originalRank` field is used instead, which correctly handles tied ranks.

### Linked Issue

Fixes #151 

### Changes Made
- Updated `computeRankChanges` function to use `user.originalRank` 
  instead of `idx + 1` for both previous and current rank lookup
- Updated `changes.json` generation logic to use `user.originalRank` 
  instead of `idx + 1` for rank movement detection

## Type of Change

<!-- Put an 'x' inside the brackets that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

<!-- Describe how you tested your changes -->

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x]I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

<!-- Required for UI/Visual changes whenever possible -->
