### PR TITLE
added non-activity section

### DIFF
--- a/frontend/js/leaderboard/render.js
+++ b/frontend/js/leaderboard/render.js
@@ -100,7 +100,8 @@ function createExternalIcon() {
 
 function renderLeaderboardRow(user, rank) {
   const rankTagEl = createRankTagElement(rank);
-  const rankChangeEl = user.score > 0 ? createRankChangeElement(user.rankChange) : null;
+  const rankChangeEl =
+    user.score > 0 ? createRankChangeElement(user.rankChange) : null;
   const easyPoints = 1;
   const mediumPoints = 3;
   const hardPoints = 5;
@@ -311,7 +312,8 @@ function renderMobileCard(user, rank) {
   const mobileName = document.createElement("div");
   mobileName.className = "mobile-name";
   const mobileRankTagEl = createRankTagElement(rank);
-  const mobileRankChangeEl = user.score > 0 ? createRankChangeElement(user.rankChange) : null;
+  const mobileRankChangeEl =
+    user.score > 0 ? createRankChangeElement(user.rankChange) : null;
   if (mobileRankTagEl) {
     mobileName.appendChild(mobileRankTagEl);
   }

--- a/frontend/js/leaderboard/render.js
+++ b/frontend/js/leaderboard/render.js
@@ -100,7 +100,7 @@ function createExternalIcon() {
 
 function renderLeaderboardRow(user, rank) {
   const rankTagEl = createRankTagElement(rank);
-  const rankChangeEl = createRankChangeElement(user.rankChange);
+  const rankChangeEl = user.score > 0 ? createRankChangeElement(user.rankChange) : null;
   const easyPoints = 1;
   const mediumPoints = 3;
   const hardPoints = 5;
@@ -136,7 +136,16 @@ function renderLeaderboardRow(user, rank) {
   // Rank (numeric — safe)
   const rankDiv = document.createElement("div");
   rankDiv.className = "rank";
-  rankDiv.textContent = rank;
+  if (rank === "") {
+    rankDiv.textContent = "[IDLE]";
+    rankDiv.style.color = "var(--text-dim)";
+    rankDiv.style.fontSize = "0.75rem";
+  } else if (rank === "--") {
+    rankDiv.textContent = "[--]";
+    rankDiv.style.color = "var(--text-dim)";
+  } else {
+    rankDiv.textContent = rank;
+  }
   row.appendChild(rankDiv);
 
   // Name cell — tag is safe DOM element, name is user-controlled (textContent)
@@ -260,7 +269,16 @@ function renderMobileCard(user, rank) {
 
   const mobileRank = document.createElement("div");
   mobileRank.className = "mobile-rank";
-  mobileRank.textContent = `#${rank}`;
+  if (rank === "") {
+    mobileRank.textContent = "[IDLE]";
+    mobileRank.style.color = "var(--text-dim)";
+    mobileRank.style.fontSize = "0.75rem";
+  } else if (rank === "--") {
+    mobileRank.textContent = "[--]";
+    mobileRank.style.color = "var(--text-dim)";
+  } else {
+    mobileRank.textContent = `#${rank}`;
+  }
   cardHeader.appendChild(mobileRank);
 
   const mobileScore = document.createElement("div");
@@ -293,7 +311,7 @@ function renderMobileCard(user, rank) {
   const mobileName = document.createElement("div");
   mobileName.className = "mobile-name";
   const mobileRankTagEl = createRankTagElement(rank);
-  const mobileRankChangeEl = createRankChangeElement(user.rankChange);
+  const mobileRankChangeEl = user.score > 0 ? createRankChangeElement(user.rankChange) : null;
   if (mobileRankTagEl) {
     mobileName.appendChild(mobileRankTagEl);
   }

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -303,20 +303,27 @@
           countEl.textContent = "";
           countEl.style.opacity = "0";
         }
-        document.getElementById("prev-page-btn").disabled = currentPage === 1;
 
+        const renderableData =
+          activeDatasetType === "overall"
+            ? filteredData.filter((user) => user.score > 0)
+            : filteredData;
+
+        const totalPages = Math.ceil(renderableData.length / itemsPerPage) || 1;
+        document.getElementById("prev-page-btn").disabled = currentPage === 1;
         document.getElementById("next-page-btn").disabled =
-          currentPage === Math.ceil(filteredData.length / itemsPerPage);
+          currentPage === totalPages;
+
         const statsEl = document.getElementById("leaderboard-stats");
 
-        const totalPages = Math.ceil(filteredData.length / itemsPerPage);
-
         const startRow =
-          filteredData.length === 0 ? 0 : (currentPage - 1) * itemsPerPage + 1;
+          renderableData.length === 0
+            ? 0
+            : (currentPage - 1) * itemsPerPage + 1;
 
         const endRow = Math.min(
           currentPage * itemsPerPage,
-          filteredData.length,
+          renderableData.length,
         );
 
         statsEl.innerHTML = `
@@ -326,15 +333,15 @@
               margin-bottom:1rem;
               font-family:'Fira Code', monospace;
             ">
-              Total Users: ${filteredData.length}
+              Total Users: ${renderableData.length}
               | Showing: ${startRow}-${endRow}
               | Page: ${currentPage}/${totalPages}
             </div>
           `;
-        renderLeaderboard(filteredData);
+        renderLeaderboard(filteredData, totalPages);
       }
 
-      function renderLeaderboard(data) {
+      function renderLeaderboard(data, totalPages) {
         const body = document.getElementById("leaderboard-body");
         const mobileCards = document.getElementById("mobile-cards");
 
@@ -346,48 +353,64 @@
         const startIndex = (currentPage - 1) * itemsPerPage;
         const endIndex = startIndex + itemsPerPage;
 
-        const displayData = isSearching
-          ? data
-          : data.slice(startIndex, endIndex);
+        let activeList = data;
+        let inactiveList = [];
 
-        if (displayData.length === 0) {
-          body.innerHTML = `
-                        <div class="no-results">
-                            [SYS]: NO_MATCHING_USERS_FOUND
-                        </div>
-                    `;
+        if (activeDatasetType === "overall") {
+          activeList = data.filter((user) => user.score > 0);
+          inactiveList = data.filter((user) => user.score === 0);
+        }
 
-          mobileCards.innerHTML = `
-                        <div class="no-results">
-                            [SYS]: NO_MATCHING_USERS_FOUND
-                        </div>
-                    `;
+        const displayActiveData =
+          isSearching || activeDatasetType !== "overall"
+            ? activeList
+            : activeList.slice(startIndex, endIndex);
+
+        if (displayActiveData.length === 0 && inactiveList.length === 0) {
+          const emptyStateHtml = `<div class="no-results" style="grid-column: 1 / -1;">[SYS]: NO_MATCHING_USERS_FOUND</div>`;
+          body.innerHTML = emptyStateHtml;
+          mobileCards.innerHTML = emptyStateHtml;
           return;
         }
 
-        displayData.forEach((user, index) => {
+        displayActiveData.forEach((user, index) => {
           const rank =
             user.originalRank !== undefined
               ? user.originalRank
               : startIndex + index + 1;
-          const row = renderLeaderboardRow(user, rank);
-          const card = renderMobileCard(user, rank);
-          body.appendChild(row);
-          mobileCards.appendChild(card);
-        });
-        renderPagination(data.length);
-      }
-      function setActiveTab(activeTab) {
-        document.querySelectorAll(".tab").forEach((tab) => {
-          tab.classList.remove("active");
-          if (tab.dataset.tab === activeTab) {
-            tab.classList.add("active");
-          }
+          body.appendChild(renderLeaderboardRow(user, rank));
+          mobileCards.appendChild(renderMobileCard(user, rank));
         });
 
-        if (!leaderboardData[activeTab]) {
-          return;
+        if (
+          activeDatasetType === "overall" &&
+          inactiveList.length > 0 &&
+          (currentPage === totalPages || isSearching)
+        ) {
+          const dividerText = "── [ SECTION: NO ACTIVITY YET ] ──";
+
+          const tableHeader = document.createElement("div");
+          tableHeader.className = "no-results";
+          tableHeader.style.gridColumn = "1 / -1";
+          tableHeader.innerText = dividerText;
+          body.appendChild(tableHeader);
+
+          const mobileHeader = document.createElement("div");
+          mobileHeader.className = "no-results";
+          mobileHeader.innerText = dividerText;
+          mobileCards.appendChild(mobileHeader);
+
+          inactiveList.forEach((user) => {
+            body.appendChild(renderLeaderboardRow(user, "--"));
+            mobileCards.appendChild(renderMobileCard(user, "--"));
+          });
         }
+
+        renderPagination(activeList.length);
+      }
+
+      function setActiveTab(activeTab) {
+        if (!leaderboardData[activeTab]) return;
 
         activeDatasetType = activeTab;
         currentPage = 1;

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -401,12 +401,15 @@
           countEl.style.opacity = "0";
         }
 
-        const overallDataset = window.leaderboardData["overall"] || originalData || [];
+        const overallDataset = window.leaderboardData && window.leaderboardData["overall"] 
+          ? window.leaderboardData["overall"] 
+          : (originalData || []);
+
         const zeroScoreUserIds = new Set(
-          overallDataset.filter(user => user.score === 0).map(user => user.id)
+          overallDataset.filter(user => (user && user.score === 0)).map(user => user.id)
         );
 
-        const renderableData = filteredData.filter((user) => !zeroScoreUserIds.has(user.id));
+        const renderableData = filteredData.filter((user) => user && !zeroScoreUserIds.has(user.id));
 
         const totalPages = Math.ceil(renderableData.length / itemsPerPage) || 1;
         document.getElementById("prev-page-btn").disabled = currentPage === 1;
@@ -456,10 +459,9 @@
         const activeList = data.filter((user) => !zeroScoreUserIds.has(user.id));
         const inactiveList = data.filter((user) => zeroScoreUserIds.has(user.id));
 
-        const displayActiveData =
-          isSearching || activeDatasetType !== "overall"
-            ? activeList
-            : activeList.slice(startIndex, endIndex);
+        const displayActiveData = isSearching 
+          ? activeList 
+          : activeList.slice(startIndex, endIndex);
 
         if (displayActiveData.length === 0 && inactiveList.length === 0) {
           const emptyStateHtml = `<div class="no-results" style="grid-column: 1 / -1;">[SYS]: NO_MATCHING_USERS_FOUND</div>`;
@@ -500,8 +502,8 @@
           mobileCards.appendChild(mobileHeader);
 
           inactiveList.forEach((user) => {
-            body.appendChild(renderLeaderboardRow(user, "--"));
-            mobileCards.appendChild(renderMobileCard(user, "--"));
+            body.appendChild(renderLeaderboardRow(user, ""));
+            mobileCards.appendChild(renderMobileCard(user, ""));
           });
         }
 
@@ -515,6 +517,15 @@
 
         activeDatasetType = activeTab;
         currentPage = 1;
+
+        document.querySelectorAll(".tab").forEach((tab) => {
+          if (tab.dataset.tab === activeTab) {
+            tab.classList.add("active");
+          } else {
+            tab.classList.remove("active");
+          }
+        });
+
         applyFiltersAndRender();
       }
     </script>

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -401,15 +401,20 @@
           countEl.style.opacity = "0";
         }
 
-        const overallDataset = window.leaderboardData && window.leaderboardData["overall"] 
-          ? window.leaderboardData["overall"] 
-          : (originalData || []);
+        const overallDataset =
+          window.leaderboardData && window.leaderboardData["overall"]
+            ? window.leaderboardData["overall"]
+            : originalData || [];
 
         const zeroScoreUserIds = new Set(
-          overallDataset.filter(user => (user && user.score === 0)).map(user => user.id)
+          overallDataset
+            .filter((user) => user && user.score === 0)
+            .map((user) => user.id),
         );
 
-        const renderableData = filteredData.filter((user) => user && !zeroScoreUserIds.has(user.id));
+        const renderableData = filteredData.filter(
+          (user) => user && !zeroScoreUserIds.has(user.id),
+        );
 
         const totalPages = Math.ceil(renderableData.length / itemsPerPage) || 1;
         document.getElementById("prev-page-btn").disabled = currentPage === 1;
@@ -440,7 +445,7 @@
               | Page: ${currentPage}/${totalPages}
             </div>
           `;
-          
+
         renderLeaderboard(filteredData, zeroScoreUserIds, totalPages);
       }
 
@@ -456,11 +461,15 @@
         const startIndex = (currentPage - 1) * itemsPerPage;
         const endIndex = startIndex + itemsPerPage;
 
-        const activeList = data.filter((user) => !zeroScoreUserIds.has(user.id));
-        const inactiveList = data.filter((user) => zeroScoreUserIds.has(user.id));
+        const activeList = data.filter(
+          (user) => !zeroScoreUserIds.has(user.id),
+        );
+        const inactiveList = data.filter((user) =>
+          zeroScoreUserIds.has(user.id),
+        );
 
-        const displayActiveData = isSearching 
-          ? activeList 
+        const displayActiveData = isSearching
+          ? activeList
           : activeList.slice(startIndex, endIndex);
 
         if (displayActiveData.length === 0 && inactiveList.length === 0) {
@@ -475,7 +484,7 @@
             user.originalRank !== undefined
               ? user.originalRank
               : startIndex + index + 1;
-              
+
           if (activeDatasetType !== "overall" && user.score === 0) {
             rank = "--";
           }

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -401,10 +401,12 @@
           countEl.style.opacity = "0";
         }
 
-        const renderableData =
-          activeDatasetType === "overall"
-            ? filteredData.filter((user) => user.score > 0)
-            : filteredData;
+        const overallDataset = window.leaderboardData["overall"] || originalData || [];
+        const zeroScoreUserIds = new Set(
+          overallDataset.filter(user => user.score === 0).map(user => user.id)
+        );
+
+        const renderableData = filteredData.filter((user) => !zeroScoreUserIds.has(user.id));
 
         const totalPages = Math.ceil(renderableData.length / itemsPerPage) || 1;
         document.getElementById("prev-page-btn").disabled = currentPage === 1;
@@ -430,15 +432,16 @@
               margin-bottom:1rem;
               font-family:'Fira Code', monospace;
             ">
-              Total Users: ${renderableData.length}
+              Total Users: ${filteredData.length}
               | Showing: ${startRow}-${endRow}
               | Page: ${currentPage}/${totalPages}
             </div>
           `;
-        renderLeaderboard(filteredData, totalPages);
+          
+        renderLeaderboard(filteredData, zeroScoreUserIds, totalPages);
       }
 
-      function renderLeaderboard(data, totalPages) {
+      function renderLeaderboard(data, zeroScoreUserIds, totalPages) {
         const body = document.getElementById("leaderboard-body");
         const mobileCards = document.getElementById("mobile-cards");
 
@@ -450,13 +453,8 @@
         const startIndex = (currentPage - 1) * itemsPerPage;
         const endIndex = startIndex + itemsPerPage;
 
-        let activeList = data;
-        let inactiveList = [];
-
-        if (activeDatasetType === "overall") {
-          activeList = data.filter((user) => user.score > 0);
-          inactiveList = data.filter((user) => user.score === 0);
-        }
+        const activeList = data.filter((user) => !zeroScoreUserIds.has(user.id));
+        const inactiveList = data.filter((user) => zeroScoreUserIds.has(user.id));
 
         const displayActiveData =
           isSearching || activeDatasetType !== "overall"
@@ -471,16 +469,20 @@
         }
 
         displayActiveData.forEach((user, index) => {
-          const rank =
+          let rank =
             user.originalRank !== undefined
               ? user.originalRank
               : startIndex + index + 1;
+              
+          if (activeDatasetType !== "overall" && user.score === 0) {
+            rank = "--";
+          }
+
           body.appendChild(renderLeaderboardRow(user, rank));
           mobileCards.appendChild(renderMobileCard(user, rank));
         });
 
         if (
-          activeDatasetType === "overall" &&
           inactiveList.length > 0 &&
           (currentPage === totalPages || isSearching)
         ) {

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -1574,7 +1574,8 @@ body.crt-scrolling {
   }
 
   .leaderboard-header,
-  .leaderboard-row {
+  .leaderboard-row,
+  .leaderboard .no-results {
     display: none;
   }
 

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -34,10 +34,14 @@ function getFileName(daysAgo) {
 function assignCompetitionRanks(sortedData) {
   let currentRank = 1;
   for (let i = 0; i < sortedData.length; i++) {
-    if (i > 0 && sortedData[i].score < sortedData[i - 1].score) {
-      currentRank = i + 1;
+    if (sortedData[i].score === 0) {
+      sortedData[i].originalRank = "--";
+    } else {
+      if (i > 0 && sortedData[i].score < sortedData[i - 1].score) {
+        currentRank = i + 1;
+      }
+      sortedData[i].originalRank = currentRank;
     }
-    sortedData[i].originalRank = currentRank;
   }
 }
 

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -34,14 +34,10 @@ function getFileName(daysAgo) {
 function assignCompetitionRanks(sortedData) {
   let currentRank = 1;
   for (let i = 0; i < sortedData.length; i++) {
-    if (sortedData[i].score === 0) {
-      sortedData[i].originalRank = "--";
-    } else {
-      if (i > 0 && sortedData[i].score < sortedData[i - 1].score) {
-        currentRank = i + 1;
-      }
-      sortedData[i].originalRank = currentRank;
+    if (i > 0 && sortedData[i].score < sortedData[i - 1].score) {
+      currentRank = i + 1;
     }
+    sortedData[i].originalRank = currentRank;
   }
 }
 


### PR DESCRIPTION
## Description

This PR improves the leaderboard experience by resolving arbitrary ranking assignments for users with 0 scores. It handles zero-score behavior differently across tabs to match the terminal-style UI theme and prevent empty layouts:
- **Overall Leaderboard:** Completely removes users with an overall score of 0 from the competitive ranks and displays them in a separate "No activity yet" section.
- **Daily/Weekly/Monthly Leaderboards:** Keeps zero-score users visible at the bottom to ensure the UI stays active, but omits their rank numbers, replacing them with a non-competitive `--` delimiter.

### Linked Issue

Fixes #93 

### Changes Made

- Excluded users with overall 0 scores from the primary competitive layout.
- Added a dedicated "No activity yet" block matching the terminal theme at the bottom of the Overall tab.
- Removed rank numbers for zero-score users in time-based tabs (Daily, Weekly, Monthly) and replaced them with `--`.
- Integrated changes with existing pagination, filtering/search logic, and mobile layouts.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [x] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

### Overall Tab Example:
```text
1. UserA (100 pts)
2. UserB (80 pts)
───────────────────
-- InactiveUser1 (No activity yet)
-- InactiveUser2 (No activity yet)