### PR TITLE
fix: pause leaderboard polling when tab is hidden using Page Visibili…

### DIFF
--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -187,27 +187,27 @@
         setupPaginationListeners();
         fetchLeaderboardData();
         // Poll every 2 minutes to detect new syncs
-       // Page Visibility API — pause polling when tab is hidden
-let pollInterval;
+        // Page Visibility API — pause polling when tab is hidden
+        let pollInterval;
 
-function startPolling() {
-  pollInterval = setInterval(fetchLeaderboardData, 2 * 60 * 1000);
-}
+        function startPolling() {
+          pollInterval = setInterval(fetchLeaderboardData, 2 * 60 * 1000);
+        }
 
-function stopPolling() {
-  clearInterval(pollInterval);
-}
+        function stopPolling() {
+          clearInterval(pollInterval);
+        }
 
-document.addEventListener('visibilitychange', () => {
-  if (document.visibilityState === 'visible') {
-    fetchLeaderboardData(); // immediate refresh when tab becomes visible
-    startPolling();
-  } else {
-    stopPolling();
-  }
-});
+        document.addEventListener("visibilitychange", () => {
+          if (document.visibilityState === "visible") {
+            fetchLeaderboardData(); // immediate refresh when tab becomes visible
+            startPolling();
+          } else {
+            stopPolling();
+          }
+        });
 
-startPolling(); 
+        startPolling();
       });
 
       const leaderboardData = {};

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -187,7 +187,27 @@
         setupPaginationListeners();
         fetchLeaderboardData();
         // Poll every 2 minutes to detect new syncs
-        setInterval(fetchLeaderboardData, 2 * 60 * 1000);
+       // Page Visibility API — pause polling when tab is hidden
+let pollInterval;
+
+function startPolling() {
+  pollInterval = setInterval(fetchLeaderboardData, 2 * 60 * 1000);
+}
+
+function stopPolling() {
+  clearInterval(pollInterval);
+}
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    fetchLeaderboardData(); // immediate refresh when tab becomes visible
+    startPolling();
+  } else {
+    stopPolling();
+  }
+});
+
+startPolling(); 
       });
 
       const leaderboardData = {};


### PR DESCRIPTION
## Description

Replaced the always-running `setInterval` with a Page Visibility API implementation that pauses polling when the browser tab is hidden and resumes immediately when the user switches back to the tab — saving unnecessary bandwidth and API calls.

### Linked Issue
Fixes #172

### Changes Made
- Removed direct `setInterval(fetchLeaderboardData, 2 * 60 * 1000)` call
- Added `startPolling()` and `stopPolling()` helper functions
- Added `visibilitychange` event listener to pause/resume polling based on tab visibility
- On tab becoming visible, triggers an immediate fetch before resuming interval

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor

## Testing
- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist
- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording
**Before:** Network requests fired every 2 minutes regardless of tab visibility.

**After:** Network requests pause when tab is hidden, resume immediately on tab focus.

> Tested via DevTools → Network tab by switching browser tabs and confirming no fetch calls during hidden state.