### PR TITLE
fix: add home route entry to 404 terminal navigation menu (#205)

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -227,6 +227,8 @@
           <span class="cmd"> ls /valid-routes</span>
         </div>
         <div class="line" style="padding-left: 1.2rem">
+          <span class="highlight"><a href="/">home/</a></span>
+          &nbsp;&nbsp;
           <span class="highlight"><a href="/leaderboard">leaderboard/</a></span>
           &nbsp;&nbsp;
           <span class="highlight"


### PR DESCRIPTION
### Overview
Closes #205

This PR adds `home/` as the first entry in the simulated terminal `ls /valid-routes` output on the 404 recovery page, providing users with a direct way to return to the site's home page.

### Changes Made
* **File Modified:** `frontend/404.html` (lines 229–239)
* Prepend the `home/` navigation entry to match the exact target output order requested in the issue.
* Wired the entry to link directly to the application root (`/`) using the existing `.highlight a` class styles for perfect green glow/hover consistency.
* Retained proper design and typography alignment by utilizing the standard `&nbsp;&nbsp;` character spacing.

### UI Layout Comparison
* **Before:** `leaderboard/  registration/  about/`
* **After:**  `home/  leaderboard/  registration/  about/`

### Verification
- [x] HTML structure renders visually aligned with the mock CLI design.
- [x] Home route properly redirects to the root path (`/`).