### PR TITLE
Optimize sync engine for stale users

### DIFF
--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -206,12 +206,62 @@ async function computeRankChanges(currentSorted, filename) {
   }
 
   const baseUrl = "https://leetcode-api-dun.vercel.app/";
+
+  const inactiveFilePath = path.join(DATA_DIR, "inactive-users.json");
+  const inactiveUsersSet = new Set();
+  try {
+    if (fs.existsSync(inactiveFilePath)) {
+      const rawInactive = fs.readFileSync(inactiveFilePath, "utf8");
+      const inactiveData = JSON.parse(rawInactive);
+      if (Array.isArray(inactiveData.inactiveUsers)) {
+        inactiveData.inactiveUsers.forEach(id => inactiveUsersSet.add(id));
+        console.log(`Loaded ${inactiveUsersSet.size} stale users into skip-filter lookup Set.`);
+      }
+    }
+  } catch (err) {
+    console.warn("Warning: Could not parse inactive-users.json, proceeding without skips:", err.message);
+  }
+
+  const overallFilepath = path.join(DATA_DIR, "overall.json");
+  let previousOverall = [];
+  try {
+    if (fs.existsSync(overallFilepath)) {
+      previousOverall = JSON.parse(fs.readFileSync(overallFilepath, "utf8"));
+    }
+  } catch (err) {
+    console.warn("No previous overall.json found, cannot recycle stale records.");
+  }
+
+  const historyMap = new Map();
+  previousOverall.forEach(oldUser => {
+    if (oldUser.id) historyMap.set(oldUser.id, oldUser);
+  });
+
   const interval = 0;
   let overallData = [];
 
   console.log(" ");
   console.log("Starting daily fetch...");
   for (const user of users) {
+    if (inactiveUsersSet.has(user.id)) {
+      const cache = historyMap.get(user.id);
+      if (cache) {
+        console.log(`⏭️  ${user.name} (${user.id}): Bypassed API (Reusing cached stats)`);
+        overallData.push({
+          name: cache.name,
+          id: cache.id,
+          data: {
+            easySolved: cache.data?.easySolved || 0,
+            mediumSolved: cache.data?.mediumSolved || 0,
+            hardSolved: cache.data?.hardSolved || 0,
+            totalSolved: cache.data?.totalSolved || 0
+          },
+          score: cache.score || 0
+        });
+        continue;
+      }
+    }
+
     const data = await fetchData(baseUrl + user.id);
     if (!data) {
       console.log(`${user.name}: skipped (API error)`);
@@ -269,7 +319,7 @@ async function computeRankChanges(currentSorted, filename) {
   console.log("Writing sorted daily data to overall file...");
   const overallFilepath = path.join(DATA_DIR, "overall.json");
 
-  let previousOverall = [];
+  previousOverall = [];
   try {
     const rawPrevious = fs.readFileSync(overallFilepath, "utf8");
     previousOverall = JSON.parse(rawPrevious);

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -214,12 +214,17 @@ async function computeRankChanges(currentSorted, filename) {
       const rawInactive = fs.readFileSync(inactiveFilePath, "utf8");
       const inactiveData = JSON.parse(rawInactive);
       if (Array.isArray(inactiveData.inactiveUsers)) {
-        inactiveData.inactiveUsers.forEach(id => inactiveUsersSet.add(id));
-        console.log(`Loaded ${inactiveUsersSet.size} stale users into skip-filter lookup Set.`);
+        inactiveData.inactiveUsers.forEach((id) => inactiveUsersSet.add(id));
+        console.log(
+          `Loaded ${inactiveUsersSet.size} stale users into skip-filter lookup Set.`,
+        );
       }
     }
   } catch (err) {
-    console.warn("Warning: Could not parse inactive-users.json, proceeding without skips:", err.message);
+    console.warn(
+      "Warning: Could not parse inactive-users.json, proceeding without skips:",
+      err.message,
+    );
   }
 
   const overallFilepath = path.join(DATA_DIR, "overall.json");
@@ -229,11 +234,13 @@ async function computeRankChanges(currentSorted, filename) {
       previousOverall = JSON.parse(fs.readFileSync(overallFilepath, "utf8"));
     }
   } catch (err) {
-    console.warn("No previous overall.json found, cannot recycle stale records.");
+    console.warn(
+      "No previous overall.json found, cannot recycle stale records.",
+    );
   }
 
   const historyMap = new Map();
-  previousOverall.forEach(oldUser => {
+  previousOverall.forEach((oldUser) => {
     if (oldUser.id) historyMap.set(oldUser.id, oldUser);
   });
 
@@ -253,9 +260,9 @@ async function computeRankChanges(currentSorted, filename) {
             easySolved: cache.data?.easySolved || 0,
             mediumSolved: cache.data?.mediumSolved || 0,
             hardSolved: cache.data?.hardSolved || 0,
-            totalSolved: cache.data?.totalSolved || 0
+            totalSolved: cache.data?.totalSolved || 0,
           },
-          score: cache.score || 0
+          score: cache.score || 0,
         });
         continue;
       }

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -246,7 +246,6 @@ async function computeRankChanges(currentSorted, filename) {
     if (inactiveUsersSet.has(user.id)) {
       const cache = historyMap.get(user.id);
       if (cache) {
-        console.log(`⏭️  ${user.name} (${user.id}): Bypassed API (Reusing cached stats)`);
         overallData.push({
           name: cache.name,
           id: cache.id,

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -213,12 +213,10 @@ async function computeRankChanges(currentSorted, filename) {
     if (fs.existsSync(inactiveFilePath)) {
       const rawInactive = fs.readFileSync(inactiveFilePath, "utf8");
       const inactiveData = JSON.parse(rawInactive);
-      if (Array.isArray(inactiveData.inactiveUsers)) {
-        inactiveData.inactiveUsers.forEach((id) => inactiveUsersSet.add(id));
-        console.log(
-          `Loaded ${inactiveUsersSet.size} stale users into skip-filter lookup Set.`,
-        );
-      }
+      inactiveData.inactiveUsers.forEach((id) => inactiveUsersSet.add(id));
+      console.log(
+        `Loaded ${inactiveUsersSet.size} stale users into skip-filter lookup Set.`,
+      );
     }
   } catch (err) {
     console.warn(
@@ -241,7 +239,7 @@ async function computeRankChanges(currentSorted, filename) {
 
   const historyMap = new Map();
   previousOverall.forEach((oldUser) => {
-    if (oldUser.id) historyMap.set(oldUser.id, oldUser);
+    historyMap.set(oldUser.id, oldUser);
   });
 
   const interval = 0;
@@ -253,17 +251,8 @@ async function computeRankChanges(currentSorted, filename) {
     if (inactiveUsersSet.has(user.id)) {
       const cache = historyMap.get(user.id);
       if (cache) {
-        overallData.push({
-          name: cache.name,
-          id: cache.id,
-          data: {
-            easySolved: cache.data?.easySolved || 0,
-            mediumSolved: cache.data?.mediumSolved || 0,
-            hardSolved: cache.data?.hardSolved || 0,
-            totalSolved: cache.data?.totalSolved || 0,
-          },
-          score: cache.score || 0,
-        });
+        console.log(`${user.name}: recycled (inactive)`);
+        overallData.push(cache);
         continue;
       }
     }
@@ -323,15 +312,6 @@ async function computeRankChanges(currentSorted, filename) {
   stableSortByScore(overallData);
   assignCompetitionRanks(overallData);
   console.log("Writing sorted daily data to overall file...");
-  const overallFilepath = path.join(DATA_DIR, "overall.json");
-
-  previousOverall = [];
-  try {
-    const rawPrevious = fs.readFileSync(overallFilepath, "utf8");
-    previousOverall = JSON.parse(rawPrevious);
-  } catch (err) {
-    console.warn("No previous overall.json found, skipping diff.");
-  }
 
   await computeRankChanges(overallData, "overall.json");
   try {


### PR DESCRIPTION
## Description

This PR optimizes the 5-minute leaderboard synchronization engine (`scripts/sync-leaderboard.js`) to handle growing user profiles efficiently. Instead of executing heavy API network requests for completely inactive or stale profiles every 5 minutes, the script now ingests the newly created `inactive-users.json` tracking file at startup. 

Profiles flagged as stale completely bypass the `fetchData()` network call, and their last known snapshot records are recycled directly from the previous execution's overall dataset. This heavily reduces external network load, avoids API rate-limiting blocks, and significantly accelerates the GitHub Actions workflow execution times.

### Linked Issue

Fixes #188 

### Changes Made

* **Lookup Set Initialization:** Added startup logic to parse `inactive-users.json` and loaded the profile IDs into a high-performance `Set` lookup structure.
* **Short-Circuit Verification:** Configured a validation rule within the core user-tracking loop to isolate inactive user IDs.
* **Snapshot Recycling:** Integrated data recovery logic that copies stable user histories directly from `historyMap` into the new `overallData` payload when a network call is bypassed.


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording