### PR TITLE
refactor: migrate leaderboard div-based grid to semantic table (#180)

### DIFF
--- a/frontend/js/leaderboard/render.js
+++ b/frontend/js/leaderboard/render.js
@@ -110,11 +110,11 @@ function renderLeaderboardRow(user, rank) {
   const mediumScore = user.data.mediumSolved * mediumPoints;
   const hardScore = user.data.hardSolved * hardPoints;
 
-  const row = document.createElement("div");
+  const row = document.createElement("tr");
   row.className = "leaderboard-row";
 
   // Compare checkbox column
-  const checkboxCell = document.createElement("div");
+  const checkboxCell = document.createElement("td");
   checkboxCell.className = "compare-checkbox-cell";
   const checkbox = document.createElement("input");
   checkbox.type = "checkbox";
@@ -135,25 +135,27 @@ function renderLeaderboardRow(user, rank) {
   row.appendChild(checkboxCell);
 
   // Rank (numeric — safe)
-  const rankDiv = document.createElement("div");
-  rankDiv.className = "rank";
+  const rankCell = document.createElement("td");
+  rankCell.className = "rank";
   if (rank === "") {
-    rankDiv.textContent = "[IDLE]";
-    rankDiv.style.color = "var(--text-dim)";
-    rankDiv.style.fontSize = "0.75rem";
+    rankCell.textContent = "[IDLE]";
+    rankCell.style.color = "var(--text-dim)";
+    rankCell.style.fontSize = "0.75rem";
   } else if (rank === "--") {
-    rankDiv.textContent = "[--]";
-    rankDiv.style.color = "var(--text-dim)";
+    rankCell.textContent = "[--]";
+    rankCell.style.color = "var(--text-dim)";
   } else {
-    rankDiv.textContent = rank;
+    rankCell.textContent = rank;
   }
-  row.appendChild(rankDiv);
+  row.appendChild(rankCell);
 
   // Name cell — tag is safe DOM element, name is user-controlled (textContent)
-  const nameDiv = document.createElement("div");
-  nameDiv.className = "name-cell";
+  const nameCell = document.createElement("td");
+  nameCell.className = "name-cell";
+  const nameInner = document.createElement("span");
+  nameInner.className = "name-cell-inner";
   if (rankTagEl) {
-    nameDiv.appendChild(rankTagEl);
+    nameInner.appendChild(rankTagEl);
   }
   const nameTextWrapper = document.createElement("span");
   nameTextWrapper.className = "name-text";
@@ -164,12 +166,13 @@ function renderLeaderboardRow(user, rank) {
     nameTextWrapper.appendChild(rankChangeEl);
   }
 
-  nameDiv.appendChild(nameTextWrapper);
-  row.appendChild(nameDiv);
+  nameInner.appendChild(nameTextWrapper);
+  nameCell.appendChild(nameInner);
+  row.appendChild(nameCell);
 
   // Username with link and external icon — id is user-controlled (textContent)
-  const usernameDiv = document.createElement("div");
-  usernameDiv.className = "username";
+  const usernameCell = document.createElement("td");
+  usernameCell.className = "username";
   const link = document.createElement("a");
   link.href = `https://leetcode.com/u/${user.id}`;
   link.target = "_blank";
@@ -177,46 +180,48 @@ function renderLeaderboardRow(user, rank) {
   link.className = "user-link";
   link.textContent = user.id;
   link.appendChild(createExternalIcon());
-  usernameDiv.appendChild(link);
-  row.appendChild(usernameDiv);
+  usernameCell.appendChild(link);
+  row.appendChild(usernameCell);
 
   // Easy (numeric — safe)
-  const easyDiv = document.createElement("div");
-  easyDiv.className = "easy";
-  easyDiv.textContent = user.data.easySolved;
-  row.appendChild(easyDiv);
+  const easyCell = document.createElement("td");
+  easyCell.className = "easy";
+  easyCell.textContent = user.data.easySolved;
+  row.appendChild(easyCell);
 
   // Medium (numeric — safe)
-  const mediumDiv = document.createElement("div");
-  mediumDiv.className = "medium";
-  mediumDiv.textContent = user.data.mediumSolved;
-  row.appendChild(mediumDiv);
+  const mediumCell = document.createElement("td");
+  mediumCell.className = "medium";
+  mediumCell.textContent = user.data.mediumSolved;
+  row.appendChild(mediumCell);
 
   // Hard (numeric — safe)
-  const hardDiv = document.createElement("div");
-  hardDiv.className = "hard";
-  hardDiv.textContent = user.data.hardSolved;
-  row.appendChild(hardDiv);
+  const hardCell = document.createElement("td");
+  hardCell.className = "hard";
+  hardCell.textContent = user.data.hardSolved;
+  row.appendChild(hardCell);
 
   // Total (numeric — safe)
-  const totalDiv = document.createElement("div");
-  totalDiv.className = "total";
-  totalDiv.textContent = user.data.totalSolved;
-  row.appendChild(totalDiv);
+  const totalCell = document.createElement("td");
+  totalCell.className = "total";
+  totalCell.textContent = user.data.totalSolved;
+  row.appendChild(totalCell);
 
   // Score with tooltip — all content is numeric or hardcoded labels
-  const scoreDiv = document.createElement("div");
-  scoreDiv.className = "mobile-score tooltip-score";
+  const scoreCell = document.createElement("td");
+  scoreCell.className = "score-cell";
+  const scoreInner = document.createElement("div");
+  scoreInner.className = "mobile-score tooltip-score";
 
   const scoreSpan = document.createElement("span");
   scoreSpan.textContent = user.score;
-  scoreDiv.appendChild(scoreSpan);
+  scoreInner.appendChild(scoreSpan);
 
   const caretSpan = document.createElement("span");
   caretSpan.className = "score-caret";
-  scoreDiv.appendChild(caretSpan);
+  scoreInner.appendChild(caretSpan);
 
-  scoreDiv.appendChild(
+  scoreInner.appendChild(
     buildScoreTooltip(
       user,
       easyPoints,
@@ -227,7 +232,8 @@ function renderLeaderboardRow(user, rank) {
       hardScore,
     ),
   );
-  row.appendChild(scoreDiv);
+  scoreCell.appendChild(scoreInner);
+  row.appendChild(scoreCell);
   return row;
 }
 

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -198,115 +198,125 @@
           </button>
         </div>
 
-        <div class="leaderboard">
-          <div class="leaderboard-header">
-            <div class="compare-checkbox-cell"></div>
-            <div>Rank</div>
-            <div>Name</div>
-            <div>LeetCode ID</div>
-            <div class="easy">Easy</div>
-            <div class="medium">Medium</div>
-            <div class="hard">Hard</div>
-            <div class="total">Total</div>
-            <div class="score-header">
-              Score
-              <div class="tooltip-container">
-                <span class="tooltip-icon">?</span>
-                <div class="tooltip-content">
-                  <strong>Score Calculation:</strong><br />
-                  Easy = 1 point<br />
-                  Medium = 3 points<br />
-                  Hard = 5 points<br />
-                  <a href="about.html">More details</a>
+        <table class="leaderboard">
+          <thead class="leaderboard-header">
+            <tr>
+              <th scope="col" class="compare-checkbox-cell"></th>
+              <th scope="col">Rank</th>
+              <th scope="col">Name</th>
+              <th scope="col">LeetCode ID</th>
+              <th scope="col" class="easy">Easy</th>
+              <th scope="col" class="medium">Medium</th>
+              <th scope="col" class="hard">Hard</th>
+              <th scope="col" class="total">Total</th>
+              <th scope="col" class="score-header">
+                Score
+                <div class="tooltip-container">
+                  <span class="tooltip-icon">?</span>
+                  <div class="tooltip-content">
+                    <strong>Score Calculation:</strong><br />
+                    Easy = 1 point<br />
+                    Medium = 3 points<br />
+                    Hard = 5 points<br />
+                    <a href="about.html">More details</a>
+                  </div>
                 </div>
-              </div>
-            </div>
-          </div>
+              </th>
+            </tr>
+          </thead>
 
-          <div id="leaderboard-body">
+          <tbody id="leaderboard-body">
             <!-- Skeleton rows — shown on initial load, cleared by renderLeaderboard() -->
-            <div class="skeleton-row">
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-            </div>
-            <div class="skeleton-row">
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-            </div>
-            <div class="skeleton-row">
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-            </div>
-            <div class="skeleton-row">
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-            </div>
-            <div class="skeleton-row">
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-            </div>
-            <div class="skeleton-row">
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-            </div>
-            <div class="skeleton-row">
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-            </div>
-            <div class="skeleton-row">
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-              <div class="skeleton-cell"></div>
-            </div>
-          </div>
-        </div>
+            <tr class="skeleton-row">
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+            </tr>
+            <tr class="skeleton-row">
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+            </tr>
+            <tr class="skeleton-row">
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+            </tr>
+            <tr class="skeleton-row">
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+            </tr>
+            <tr class="skeleton-row">
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+            </tr>
+            <tr class="skeleton-row">
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+            </tr>
+            <tr class="skeleton-row">
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+            </tr>
+            <tr class="skeleton-row">
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+              <td class="skeleton-cell"></td>
+            </tr>
+          </tbody>
+        </table>
 
         <div class="mobile-cards" id="mobile-cards">
           <!-- Skeleton mobile cards — shown on initial load, cleared by renderLeaderboard() -->
@@ -524,7 +534,7 @@
         // Empty state — data exists but is empty array
         if (originalData.length === 0) {
           document.getElementById("leaderboard-body").innerHTML =
-            '<div class="leaderboard-empty">[SYS]: NO_LEADERBOARD_DATA_YET</div>';
+            '<tr class="leaderboard-empty"><td colspan="9">[SYS]: NO_LEADERBOARD_DATA_YET</td></tr>';
           document.getElementById("mobile-cards").innerHTML =
             '<div class="leaderboard-empty">[SYS]: NO_LEADERBOARD_DATA_YET</div>';
           document.getElementById("leaderboard-stats").innerHTML = "";
@@ -625,7 +635,7 @@
           : activeList.slice(startIndex, endIndex);
 
         if (displayActiveData.length === 0 && inactiveList.length === 0) {
-          const emptyStateHtml = `<div class="no-results" style="grid-column: 1 / -1;">[SYS]: NO_MATCHING_USERS_FOUND</div>`;
+          const emptyStateHtml = `<tr class="no-results"><td colspan="9">[SYS]: NO_MATCHING_USERS_FOUND</td></tr>`;
           body.innerHTML = emptyStateHtml;
           mobileCards.innerHTML = emptyStateHtml;
           return;
@@ -651,10 +661,12 @@
         ) {
           const dividerText = "── [ SECTION: NO ACTIVITY YET ] ──";
 
-          const tableHeader = document.createElement("div");
+          const tableHeader = document.createElement("tr");
           tableHeader.className = "no-results";
-          tableHeader.style.gridColumn = "1 / -1";
-          tableHeader.innerText = dividerText;
+          const tableHeaderCell = document.createElement("td");
+          tableHeaderCell.setAttribute("colspan", "9");
+          tableHeaderCell.innerText = dividerText;
+          tableHeader.appendChild(tableHeaderCell);
           body.appendChild(tableHeader);
 
           const mobileHeader = document.createElement("div");

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -239,7 +239,13 @@ body.crt-scrolling {
   display: none !important;
 }
 
-.leaderboard.compare-mode .compare-checkbox-cell,
+/* Table context: use table-cell for proper table layout */
+.leaderboard.compare-mode .compare-checkbox-cell {
+  display: table-cell !important;
+  vertical-align: middle;
+  text-align: center;
+}
+
 .mobile-cards.compare-mode .compare-checkbox-cell {
   display: flex !important;
 }
@@ -828,37 +834,84 @@ body.crt-scrolling {
 
 /* --- Leaderboard --- */
 .leaderboard {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: separate;
+  border-spacing: 0;
   background: var(--bg-surface);
   border: 1px solid var(--border-bright);
   border-radius: 6px;
-  overflow: visible;
   box-shadow: 0 0 30px rgba(0, 255, 65, 0.03);
 }
 
 .leaderboard-header {
-  display: grid;
-  grid-template-columns: 55px 1fr 170px 65px 65px 65px 85px 85px;
-  padding: 0.7rem 1.25rem;
   background: var(--bg-raised);
   font-weight: 700;
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 1px;
   color: var(--green-dim);
+}
+
+.leaderboard-header tr {
   border-bottom: 1px solid var(--border-bright);
+}
+
+.leaderboard-header th {
+  padding: 0.7rem 1.25rem;
+  font-weight: 700;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--green-dim);
+  text-align: left;
   position: sticky;
   top: 52px;
   z-index: 99;
+  background: var(--bg-raised);
 }
 
+/* Column widths for the leaderboard table */
+.leaderboard-header th:nth-child(1) {
+  width: 40px;
+} /* checkbox */
+.leaderboard-header th:nth-child(2) {
+  width: 55px;
+} /* rank */
+.leaderboard-header th:nth-child(3) {
+} /* name - auto */
+.leaderboard-header th:nth-child(4) {
+  width: 170px;
+} /* username */
+.leaderboard-header th:nth-child(5) {
+  width: 65px;
+} /* easy */
+.leaderboard-header th:nth-child(6) {
+  width: 65px;
+} /* medium */
+.leaderboard-header th:nth-child(7) {
+  width: 65px;
+} /* hard */
+.leaderboard-header th:nth-child(8) {
+  width: 85px;
+} /* total */
+.leaderboard-header th:nth-child(9) {
+  width: 85px;
+} /* score */
+
 .leaderboard-row {
-  display: grid;
-  grid-template-columns: 55px 1fr 170px 65px 65px 65px 85px 85px;
+  font-size: 0.88rem;
+}
+
+.leaderboard-row td {
   padding: 0.6rem 1.25rem;
   border-bottom: 1px solid var(--border);
-  transition: background 0.1s ease;
-  align-items: center;
-  font-size: 0.88rem;
+  vertical-align: middle;
+}
+
+.leaderboard-row:last-child td {
+  border-bottom: none;
 }
 
 .leaderboard-row:nth-child(even) {
@@ -869,20 +922,19 @@ body.crt-scrolling {
   background: var(--green-muted);
 }
 
-.leaderboard-row:last-child {
-  border-bottom: none;
-}
-
 .rank {
-  display: flex;
-  align-items: center;
   font-size: 1rem;
   font-weight: 700;
   color: var(--green);
+  text-align: center;
 }
 
 .name-cell {
-  display: flex;
+  text-align: left;
+}
+
+.name-cell-inner {
+  display: inline-flex;
   align-items: center;
   gap: 8px;
 }
@@ -982,14 +1034,21 @@ body.crt-scrolling {
 
 .easy {
   color: #1cbaba;
+  text-align: center;
 }
 
 .medium {
   color: #ffb700;
+  text-align: center;
 }
 
 .hard {
   color: #f63737;
+  text-align: center;
+}
+
+.total {
+  text-align: center;
 }
 
 .score {
@@ -1003,6 +1062,14 @@ body.crt-scrolling {
   color: #ffffff;
   font-weight: 700;
   text-shadow: 0 0 8px rgba(255, 255, 255, 0.25);
+}
+
+.score-cell {
+  text-align: center;
+}
+
+.score-cell .mobile-score {
+  display: inline-flex;
 }
 
 /* -- Mobile Cards -- */
@@ -1573,6 +1640,7 @@ body.crt-scrolling {
     border-bottom: none;
   }
 
+  .leaderboard,
   .leaderboard-header,
   .leaderboard-row,
   .leaderboard .no-results {
@@ -2147,6 +2215,7 @@ body::-webkit-scrollbar-thumb {
 .score-header {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
 }
 
@@ -2864,20 +2933,15 @@ body::-webkit-scrollbar-thumb {
    LeetCode Leaderboard Peer Comparison Module
    ========================================================================== */
 
-/* --- Grid Adjustments for Comparison Mode --- */
+/* --- Table Adjustments for Comparison Mode --- */
 .compare-checkbox-cell {
   display: none;
-  align-items: center;
-  justify-content: center;
+  vertical-align: middle;
+  text-align: center;
 }
 
 .leaderboard.compare-mode .compare-checkbox-cell {
-  display: flex;
-}
-
-.leaderboard.compare-mode .leaderboard-header,
-.leaderboard.compare-mode .leaderboard-row {
-  grid-template-columns: 40px 55px 1fr 170px 65px 65px 65px 85px 85px;
+  display: table-cell;
 }
 
 /* Custom Green/Terminal Style Checkboxes */
@@ -3205,17 +3269,13 @@ input[type="checkbox"].compare-checkbox:checked::after {
 /* -- Skeleton Loading States -- */
 
 /* Fade-in for rendered leaderboard rows (smooth skeleton?data transition) */
-#leaderboard-body > .leaderboard-row {
+#leaderboard-body > tr.leaderboard-row {
   animation: fadeIn 0.25s ease-out;
 }
 
-.skeleton-row {
-  display: grid;
-  grid-template-columns: 55px 1fr 170px 65px 65px 65px 85px 85px;
-  padding: 0.7rem 1.25rem;
+.skeleton-row td {
+  padding: 0.7rem 0.25rem;
   border-bottom: 1px solid var(--border);
-  align-items: center;
-  gap: 8px;
 }
 
 .skeleton-cell {
@@ -3231,31 +3291,34 @@ input[type="checkbox"].compare-checkbox:checked::after {
   border-radius: 2px;
 }
 
-.skeleton-cell:nth-child(2) {
+/* Skeleton column widths — match the <th> column widths */
+.skeleton-row td:nth-child(1) {
+  width: 20px;
+  margin: 0 auto;
+} /* checkbox */
+.skeleton-row td:nth-child(2) {
+} /* rank */
+.skeleton-row td:nth-child(3) {
   width: 160px;
-}
-
-.skeleton-cell:nth-child(3) {
+} /* name */
+.skeleton-row td:nth-child(4) {
   width: 130px;
-}
-
-.skeleton-cell:nth-child(4),
-.skeleton-cell:nth-child(5),
-.skeleton-cell:nth-child(6) {
+} /* username */
+.skeleton-row td:nth-child(5) {
   width: 35px;
-}
-
-.skeleton-cell:nth-child(7) {
+} /* easy */
+.skeleton-row td:nth-child(6) {
+  width: 35px;
+} /* medium */
+.skeleton-row td:nth-child(7) {
+  width: 35px;
+} /* hard */
+.skeleton-row td:nth-child(8) {
   width: 45px;
-}
-
-.skeleton-cell:nth-child(8) {
+} /* total */
+.skeleton-row td:nth-child(9) {
   width: 55px;
-}
-
-.skeleton-row .skeleton-cell:first-child {
-  width: 40px;
-}
+} /* score */
 
 @keyframes skeleton-shimmer {
   0% {
@@ -3352,4 +3415,22 @@ input[type="checkbox"].compare-checkbox:checked::after {
   .skeleton-card {
     display: none;
   }
+}
+
+/* -- Leaderboard Empty State (table context) -- */
+.leaderboard-empty td {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--text-muted);
+  font-family: "Fira Code", monospace;
+  font-size: 0.9rem;
+}
+
+/* -- No Results (table context) -- */
+.no-results td {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: var(--text-muted);
+  font-family: "Fira Code", monospace;
+  font-size: 0.85rem;
 }

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -855,11 +855,11 @@ body.crt-scrolling {
 }
 
 .leaderboard-header tr {
-  border-bottom: 1px solid var(--border-bright);
+  /* header bottom border is on th */
 }
 
 .leaderboard-header th {
-  padding: 0.7rem 1.25rem;
+  padding: 0.7rem 0.3rem;
   font-weight: 700;
   font-size: 0.72rem;
   text-transform: uppercase;
@@ -870,11 +870,13 @@ body.crt-scrolling {
   top: 52px;
   z-index: 99;
   background: var(--bg-raised);
+  border-bottom: 1px solid var(--border-bright);
 }
 
 /* Column widths for the leaderboard table */
 .leaderboard-header th:nth-child(1) {
   width: 40px;
+  padding-left: 1.25rem;
 } /* checkbox */
 .leaderboard-header th:nth-child(2) {
   width: 55px;
@@ -898,6 +900,7 @@ body.crt-scrolling {
 } /* total */
 .leaderboard-header th:nth-child(9) {
   width: 85px;
+  padding-right: 1.25rem;
 } /* score */
 
 .leaderboard-row {
@@ -905,9 +908,17 @@ body.crt-scrolling {
 }
 
 .leaderboard-row td {
-  padding: 0.6rem 1.25rem;
+  padding: 0.6rem 0.3rem;
   border-bottom: 1px solid var(--border);
   vertical-align: middle;
+}
+
+.leaderboard-row td:first-child {
+  padding-left: 1.25rem;
+}
+
+.leaderboard-row td:last-child {
+  padding-right: 1.25rem;
 }
 
 .leaderboard-row:last-child td {
@@ -1070,6 +1081,7 @@ body.crt-scrolling {
 
 .score-cell .mobile-score {
   display: inline-flex;
+  justify-content: center;
 }
 
 /* -- Mobile Cards -- */
@@ -2213,10 +2225,11 @@ body::-webkit-scrollbar-thumb {
 
 /* -- Tooltip -- */
 .score-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
+  text-align: center;
+}
+
+.score-header .tooltip-container {
+  margin-left: 6px;
 }
 
 .tooltip-container {


### PR DESCRIPTION
## Description

Migrate the leaderboard `<div>`-based CSS Grid layout to a semantic HTML `<table>` element for proper accessibility. Previously, ARIA role workarounds (PR #184) were added to the div grid as a stopgap — this change provides native table semantics instead.

### Linked Issue

Fixes #180

### Changes Made

- **leaderboard.html**: `<div class="leaderboard">` → `<table class="leaderboard">`, `<div class="leaderboard-header">` → `<thead class="leaderboard-header"><tr>` with `<th scope="col">` cells, `<div id="leaderboard-body">` → `<tbody id="leaderboard-body">`, skeleton rows → `<tr>` + `<td>` (9 cells per row, including hidden checkbox cell)
- **render.js**: `renderLeaderboardRow()` creates `<tr>`/`<td>` instead of `<div>`; empty states use `<tr><td colspan="9">` for valid table structure
- **main.css**: Grid `display: grid` / `grid-template-columns` replaced with `display: table` / `table-layout: fixed` / explicit `th:nth-child()` column widths; sticky positioning on `<th>`; cell alignment updated for table context; compare-mode checkbox uses `table-cell` instead of `flex`; mobile breakpoint hides the `<table>` itself; skeleton rows use `td` padding + nth-child width selectors

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor

## Testing

- [x] Tested locally
- [x] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

- `npx prettier --check .` passes
- `node --check` passes on render.js
- Skeleton loading → data transition confirmed
- Compare mode checkbox show/hide confirmed
- Mobile card layout preserved (table hidden at 940px breakpoint)

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

N/A — visual appearance is identical to the previous grid layout (same column widths, colors, spacing, hover states, sticky header, skeleton shimmer, mobile card view). No visual regression expected.