### PR TITLE
refactor: extract repeated daily/weekly/monthly processing into shared function (#221)

### DIFF
--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -170,6 +170,70 @@ async function computeRankChanges(currentSorted, filename) {
   });
 }
 
+/**
+ * Processes a timeframe-based leaderboard (daily/weekly/monthly) by computing
+ * per-user deltas from a previous snapshot, sorting, ranking, and writing output.
+ *
+ * @param {Array} sourceData - The overall dataset to deep-clone and process
+ * @param {string} DATA_DIR - Path to the data directory
+ * @param {string} periodName - Label for the timeframe ("daily", "weekly", "monthly")
+ * @param {number} daysAgo - Number of days to look back for the snapshot file
+ */
+async function processTimeframe(sourceData, DATA_DIR, periodName, daysAgo) {
+  const data = JSON.parse(JSON.stringify(sourceData));
+  console.log(" ");
+  console.log(`Loading previous ${periodName}'s file...`);
+  const previousFilepath = path.join(DATA_DIR, "daily", getFileName(daysAgo));
+  let previousData = [];
+  try {
+    const rawData = fs.readFileSync(previousFilepath, "utf8");
+    previousData = JSON.parse(rawData);
+    console.log(`Previous ${periodName}'s data loaded successfully`);
+  } catch (err) {
+    console.error(`Failed to load previous file: `, err.message);
+    process.exit(1);
+  }
+
+  console.log(" ");
+  console.log(`Calculating ${periodName} progress...`);
+  for (let i = 0; i < data.length; i++) {
+    const previousIndex = previousData.findIndex(
+      (obj) => obj.id === data[i].id,
+    );
+    if (previousIndex == -1) {
+      data.splice(i--, 1);
+      continue;
+    }
+    data[i].data.easySolved -= previousData[previousIndex].data.easySolved;
+    data[i].data.mediumSolved -= previousData[previousIndex].data.mediumSolved;
+    data[i].data.hardSolved -= previousData[previousIndex].data.hardSolved;
+    data[i].score =
+      data[i].data.easySolved +
+      data[i].data.mediumSolved * 3 +
+      data[i].data.hardSolved * 5;
+    data[i].data.totalSolved =
+      data[i].data.easySolved +
+      data[i].data.mediumSolved +
+      data[i].data.hardSolved;
+  }
+  console.log("Calculation done");
+  console.log("");
+
+  console.log("Sorting calculated data...");
+  stableSortByScore(data);
+  assignCompetitionRanks(data);
+  console.log(`Writing sorted ${periodName} data to ${periodName}.json...`);
+  const filepath = path.join(DATA_DIR, `${periodName}.json`);
+  await computeRankChanges(data, `${periodName}.json`);
+  try {
+    atomicWrite(filepath, data);
+    console.log(`${periodName} data saved successfully`);
+  } catch (err) {
+    console.error(`Failed to write json file: `, err.message);
+    process.exit(1);
+  }
+}
+
 (async () => {
   const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, "..", "data");
   console.log(`Using data directory: ${DATA_DIR}`);
@@ -322,173 +386,10 @@ async function computeRankChanges(currentSorted, filename) {
     process.exit(1);
   }
 
-  let dailyData = JSON.parse(JSON.stringify(overallData));
-  console.log(" ");
-  console.log("Loading previous day's file...");
-  const previousDayFilepath = path.join(DATA_DIR, "daily", getFileName(1));
-  let previousData = [];
-  try {
-    const rawData = fs.readFileSync(previousDayFilepath, "utf8");
-    previousData = JSON.parse(rawData);
-    console.log("Previous day's data loaded successfully");
-  } catch (err) {
-    console.error(`Failed to load previous file: `, err.message);
-    process.exit(1);
-  }
-
-  console.log(" ");
-  console.log("Calculating daily progress...");
-  for (let i = 0; i < dailyData.length; i++) {
-    const previousIndex = previousData.findIndex(
-      (obj) => obj.id === dailyData[i].id,
-    );
-    if (previousIndex == -1) {
-      dailyData.splice(i--, 1);
-      continue;
-    }
-
-    dailyData[i].data.easySolved -= previousData[previousIndex].data.easySolved;
-    dailyData[i].data.mediumSolved -=
-      previousData[previousIndex].data.mediumSolved;
-    dailyData[i].data.hardSolved -= previousData[previousIndex].data.hardSolved;
-
-    dailyData[i].score =
-      dailyData[i].data.easySolved +
-      dailyData[i].data.mediumSolved * 3 +
-      dailyData[i].data.hardSolved * 5;
-    dailyData[i].data.totalSolved =
-      dailyData[i].data.easySolved +
-      dailyData[i].data.mediumSolved +
-      dailyData[i].data.hardSolved;
-  }
-  console.log("Calculation done");
-  console.log("");
-
-  console.log("Sorting calculated data...");
-  stableSortByScore(dailyData);
-  assignCompetitionRanks(dailyData);
-  console.log("Writing sorted daily data to daily.json...");
-  const dailyFilepath = path.join(DATA_DIR, "daily.json");
-  await computeRankChanges(dailyData, "daily.json");
-  try {
-    atomicWrite(dailyFilepath, dailyData);
-    console.log("Daily data saved successfully");
-  } catch (err) {
-    console.error(`Failed to write json file: `, err.message);
-    process.exit(1);
-  }
-
-  let weeklyData = JSON.parse(JSON.stringify(overallData));
-  console.log(" ");
-  console.log("Loading previous week's file...");
-  const previousWeekFilepath = path.join(DATA_DIR, "daily", getFileName(7));
-  previousData = [];
-  try {
-    const rawData = fs.readFileSync(previousWeekFilepath, "utf8");
-    previousData = JSON.parse(rawData);
-    console.log("Previous week's data loaded successfully");
-  } catch (err) {
-    console.error(`Failed to load previous file: `, err.message);
-    process.exit(1);
-  }
-
-  console.log(" ");
-  console.log("Calculating weekly progress...");
-  for (let i = 0; i < weeklyData.length; i++) {
-    const previousIndex = previousData.findIndex(
-      (obj) => obj.id === weeklyData[i].id,
-    );
-    if (previousIndex == -1) {
-      weeklyData.splice(i--, 1);
-      continue;
-    }
-    weeklyData[i].data.easySolved -=
-      previousData[previousIndex].data.easySolved;
-    weeklyData[i].data.mediumSolved -=
-      previousData[previousIndex].data.mediumSolved;
-    weeklyData[i].data.hardSolved -=
-      previousData[previousIndex].data.hardSolved;
-    weeklyData[i].score =
-      weeklyData[i].data.easySolved +
-      weeklyData[i].data.mediumSolved * 3 +
-      weeklyData[i].data.hardSolved * 5;
-    weeklyData[i].data.totalSolved =
-      weeklyData[i].data.easySolved +
-      weeklyData[i].data.mediumSolved +
-      weeklyData[i].data.hardSolved;
-  }
-  console.log("Calculation done");
-  console.log("");
-
-  console.log("Sorting calculated data...");
-  stableSortByScore(weeklyData);
-  assignCompetitionRanks(weeklyData);
-  console.log("Writing sorted weekly data to weekly.json...");
-  const weeklyFilepath = path.join(DATA_DIR, "weekly.json");
-  await computeRankChanges(weeklyData, "weekly.json");
-  try {
-    atomicWrite(weeklyFilepath, weeklyData);
-    console.log("Weekly data saved successfully");
-  } catch (err) {
-    console.error(`Failed to write json file: `, err.message);
-    process.exit(1);
-  }
-
-  let monthlyData = JSON.parse(JSON.stringify(overallData));
-  console.log(" ");
-  console.log("Loading previous month's file...");
-  const previousMonthFilepath = path.join(DATA_DIR, "daily", getFileName(30));
-  previousData = [];
-  try {
-    const rawData = fs.readFileSync(previousMonthFilepath, "utf8");
-    previousData = JSON.parse(rawData);
-    console.log("Previous week's data loaded successfully");
-  } catch (err) {
-    console.error(`Failed to load previous file: `, err.message);
-    process.exit(1);
-  }
-
-  console.log(" ");
-  console.log("Calculating monthly progress...");
-  for (let i = 0; i < monthlyData.length; i++) {
-    const previousIndex = previousData.findIndex(
-      (obj) => obj.id === monthlyData[i].id,
-    );
-    if (previousIndex == -1) {
-      monthlyData.splice(i--, 1);
-      continue;
-    }
-    monthlyData[i].data.easySolved -=
-      previousData[previousIndex].data.easySolved;
-    monthlyData[i].data.mediumSolved -=
-      previousData[previousIndex].data.mediumSolved;
-    monthlyData[i].data.hardSolved -=
-      previousData[previousIndex].data.hardSolved;
-    monthlyData[i].score =
-      monthlyData[i].data.easySolved +
-      monthlyData[i].data.mediumSolved * 3 +
-      monthlyData[i].data.hardSolved * 5;
-    monthlyData[i].data.totalSolved =
-      monthlyData[i].data.easySolved +
-      monthlyData[i].data.mediumSolved +
-      monthlyData[i].data.hardSolved;
-  }
-  console.log("Calculation done");
-  console.log("");
-
-  console.log("Sorting calculated data...");
-  stableSortByScore(monthlyData);
-  assignCompetitionRanks(monthlyData);
-  console.log("Writing sorted monthly data to monthly.json...");
-  const monthlyFilepath = path.join(DATA_DIR, "monthly.json");
-  await computeRankChanges(monthlyData, "monthly.json");
-  try {
-    atomicWrite(monthlyFilepath, monthlyData);
-    console.log("Monthly data saved successfully");
-  } catch (err) {
-    console.error(`Failed to write json file: `, err.message);
-    process.exit(1);
-  }
+  // Process timeframe-based leaderboards using the shared function
+  await processTimeframe(overallData, DATA_DIR, "daily", 1);
+  await processTimeframe(overallData, DATA_DIR, "weekly", 7);
+  await processTimeframe(overallData, DATA_DIR, "monthly", 30);
 
   console.log("Generating changes.json...");
   const changesFilepath = path.join(DATA_DIR, "changes.json");


### PR DESCRIPTION
## Description

Extracts three duplicated ~55-line blocks (daily, weekly, monthly timeframe processing) in `scripts/sync-leaderboard.js` into a single shared `processTimeframe()` function. Reduces file by ~99 lines with identical behavior.

### Linked Issue

Fixes #221

### Changes Made

- Added `async function processTimeframe(sourceData, DATA_DIR, periodName, daysAgo)` with JSDoc — deep-clones source data, loads previous snapshot, computes per-user deltas, calculates scores, sorts, ranks, tracks rank changes, and writes output
- Replaced three duplicated blocks with `await processTimeframe(overallData, DATA_DIR, "daily", 1)`, `await processTimeframe(overallData, DATA_DIR, "weekly", 7)`, and `await processTimeframe(overallData, DATA_DIR, "monthly", 30)`
- Moved deep-clone pattern (`JSON.parse(JSON.stringify(...))`) inside the function instead of each block

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced
- Verified with `node --check scripts/sync-leaderboard.js` and `npx prettier --check scripts/sync-leaderboard.js`

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

N/A — backend refactor, no UI changes.