### PR TITLE
security: add rate limiting to /api/user/:username endpoint (#222)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.10.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.5.2",
         "helmet": "^8.2.0"
       },
       "devDependencies": {
@@ -374,6 +375,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -629,6 +648,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "axios": "^1.10.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.5.2",
     "helmet": "^8.2.0"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -5,11 +5,15 @@ const path = require("path");
 const fs = require("fs");
 const crypto = require("crypto");
 const fetchUserInfo = require("./scripts/fetch-user-info");
+const { rateLimit } = require("express-rate-limit");
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(cors());
+
+// Trust Render.com proxy so req.ip returns real client IP
+app.set("trust proxy", 1);
 
 // 1. Per-request nonce generator (used by CSP and HTML nonce injection)
 app.use((req, res, next) => {
@@ -123,6 +127,22 @@ app.get("/uptime", (req, res) => {
 app.get("/user/:username", (req, res) => {
   serveHtml(res, path.join(__dirname, "frontend", "user.html"));
 });
+
+// ---- Rate limiter for API endpoint ----
+const apiLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1-minute window
+  limit: parseInt(process.env.API_RATE_LIMIT, 10) || 30,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  message: { error: "Rate limit exceeded", retryAfter: 60 },
+  handler: (req, res, next, options) => {
+    res.status(options.statusCode);
+    res.set("Retry-After", Math.ceil(options.windowMs / 1000));
+    res.json(options.message);
+  },
+});
+
+app.use("/api/user/:username", apiLimiter);
 
 app.get("/api/user/:username", async (req, res) => {
   const username = req.params.username;


### PR DESCRIPTION
## Description

Adds rate limiting to the `/api/user/:username` endpoint using `express-rate-limit` v8.5.2. Caps requests at 30 per minute per IP (configurable via `API_RATE_LIMIT` env var) to prevent abuse, protect Render.com free tier resources, and shield the downstream LeetCode API wrapper from excessive calls.

### Linked Issue

Fixes #222

### Changes Made

- Installed `express-rate-limit` as a production dependency
- Set `app.set("trust proxy", 1)` so `req.ip` returns the real client IP behind Render.com's reverse proxy
- Created an `apiLimiter` with a 1-minute window, 30 max requests, modern `RateLimit-*` headers, a custom `Retry-After` header, and a JSON error response `{ "error": "Rate limit exceeded", "retryAfter": 60 }`
- Applied the limiter to `/api/user/:username` via `app.use()` before the route handler

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced
- Verified with `node --check server.js` and `npx prettier --check server.js`

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

N/A — backend-only security change, no UI impact.