### PR TITLE
fix: prevent floating compare bar DOM accumulation on repeated toggle(#225)

### DIFF
--- a/frontend/js/leaderboard/compare.js
+++ b/frontend/js/leaderboard/compare.js
@@ -203,7 +203,7 @@ function updateFloatingCompareBar() {
   let bar = document.getElementById("floating-compare-bar");
 
   if (window.selectedUsers.length === 0) {
-    if (bar) bar.style.display = "none";
+    if (bar) bar.remove();
     return;
   }
 
@@ -211,6 +211,21 @@ function updateFloatingCompareBar() {
     bar = document.createElement("div");
     bar.id = "floating-compare-bar";
     bar.className = "floating-compare-bar";
+    // Event delegation: single listener handles all button clicks
+    bar.addEventListener("click", (e) => {
+      const btn = e.target.closest("button");
+      if (!btn) return;
+      if (btn.id === "floating-btn-clear") {
+        clearSelectedUsers();
+      } else if (btn.id === "floating-btn-cancel") {
+        toggleCompareMode();
+      } else if (
+        btn.id === "floating-btn-compare" &&
+        window.selectedUsers.length >= 2
+      ) {
+        openCompareModal();
+      }
+    });
     document.body.appendChild(bar);
   }
 
@@ -229,19 +244,6 @@ function updateFloatingCompareBar() {
       <button id="floating-btn-cancel" class="btn-clear" style="color: var(--amber);">Cancel</button>
     </div>
   `;
-
-  // Bind click handlers
-  document
-    .getElementById("floating-btn-clear")
-    .addEventListener("click", clearSelectedUsers);
-  document
-    .getElementById("floating-btn-cancel")
-    .addEventListener("click", toggleCompareMode);
-  if (count >= 2) {
-    document
-      .getElementById("floating-btn-compare")
-      .addEventListener("click", openCompareModal);
-  }
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes two issues in `updateFloatingCompareBar()` that caused DOM element accumulation and fragile event listener re-binding on repeated compare mode toggling. The floating compare bar is now fully removed from DOM when no users are selected, and button clicks are handled via event delegation instead of individual `addEventListener` calls.

### Linked Issue

Fixes #225

### Changes Made

- **`clearSelectedUsers()` path**: Changed `bar.style.display = "none"` to `bar.remove()` — the bar element is now fully removed from DOM when no users are selected instead of just hidden
- **Event delegation**: Replaced three individual `addEventListener` calls on buttons with a single delegated `click` listener on the bar element, bound only once when the bar is first created. The listener uses `e.target.closest("button")` to route clicks to the correct handler (`clearSelectedUsers`, `toggleCompareMode`, or `openCompareModal`)
- When compare mode is re-activated, `document.getElementById()` returns null (bar was removed), so a fresh bar is created with a single fresh delegated listener — clean slate every time

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced
- Verified with `npx prettier --check frontend/js/leaderboard/compare.js`

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

N/A — no visual change, same behavior with cleaner DOM lifecycle.