### PR TITLE
fix: add 300ms debounce to leaderboard search input

### DIFF
--- a/frontend/js/leaderboard/search.js
+++ b/frontend/js/leaderboard/search.js
@@ -3,13 +3,25 @@ function setupSearchListeners() {
   const shortcutBadge = document.getElementById("search-shortcut");
   const clearBtn = document.getElementById("clear-search");
 
-  searchInput.addEventListener("input", (e) => {
-    currentSearchTerm = e.target.value.toLowerCase().trim();
+ function debounce(fn, delay) {
+    let timer;
+    return (...args) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn(...args), delay);
+    };
+  }
 
-    clearBtn.style.display = e.target.value.trim() !== "" ? "flex" : "none";
+  searchInput.addEventListener(
+    "input",
+    debounce((e) => {
+      currentSearchTerm = e.target.value.toLowerCase().trim();
 
-    applyFiltersAndRender();
-  });
+      clearBtn.style.display =
+        e.target.value.trim() !== "" ? "flex" : "none";
+
+      applyFiltersAndRender();
+    }, 300)
+  );
   clearBtn.addEventListener("click", () => {
     searchInput.value = "";
     currentSearchTerm = "";

--- a/frontend/js/leaderboard/search.js
+++ b/frontend/js/leaderboard/search.js
@@ -3,7 +3,7 @@ function setupSearchListeners() {
   const shortcutBadge = document.getElementById("search-shortcut");
   const clearBtn = document.getElementById("clear-search");
 
- function debounce(fn, delay) {
+  function debounce(fn, delay) {
     let timer;
     return (...args) => {
       clearTimeout(timer);
@@ -16,11 +16,10 @@ function setupSearchListeners() {
     debounce((e) => {
       currentSearchTerm = e.target.value.toLowerCase().trim();
 
-      clearBtn.style.display =
-        e.target.value.trim() !== "" ? "flex" : "none";
+      clearBtn.style.display = e.target.value.trim() !== "" ? "flex" : "none";
 
       applyFiltersAndRender();
-    }, 300)
+    }, 300),
   );
   clearBtn.addEventListener("click", () => {
     searchInput.value = "";


### PR DESCRIPTION
## Description

Adds a 300ms debounce to the leaderboard search input to prevent 
unnecessary DOM filtering on every keypress. Currently, `applyFiltersAndRender()` 
is called on every single keystroke. As student count grows (currently 113+), 
this causes repeated DOM operations that degrade performance on mobile and 
lower-end devices. The debounce ensures filtering only triggers after the 
user pauses typing.

### Linked Issue

Fixes #227

### Changes Made

- Added a lightweight `debounce()` utility function inside `setupSearchListeners()` in `frontend/js/leaderboard/search.js`
- Wrapped the `input` event listener with `debounce(..., 300)`
- No changes to clear button, Ctrl+K shortcut, or Escape key logic

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor

## Testing

- [x] Tested locally
- [x] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

Debounce verified via browser console — "filter triggered" log appears 
once after typing pause, not on every keypress.