### PR TITLE
Fix negative period delta calculation in sync-leaderboard

### DIFF
--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -278,17 +278,30 @@ async function processTimeframe(
       data.splice(i--, 1);
       continue;
     }
-    data[i].data.easySolved -= previousData[previousIndex].data.easySolved;
-    data[i].data.mediumSolved -= previousData[previousIndex].data.mediumSolved;
-    data[i].data.hardSolved -= previousData[previousIndex].data.hardSolved;
-    data[i].score =
-      data[i].data.easySolved +
-      data[i].data.mediumSolved * 3 +
-      data[i].data.hardSolved * 5;
-    data[i].data.totalSolved =
-      data[i].data.easySolved +
-      data[i].data.mediumSolved +
-      data[i].data.hardSolved;
+   data[i].data.easySolved = Math.max(
+  0,
+  data[i].data.easySolved - previousData[previousIndex].data.easySolved
+);
+
+data[i].data.mediumSolved = Math.max(
+  0,
+  data[i].data.mediumSolved - previousData[previousIndex].data.mediumSolved
+);
+
+data[i].data.hardSolved = Math.max(
+  0,
+  data[i].data.hardSolved - previousData[previousIndex].data.hardSolved
+);
+
+data[i].score =
+  data[i].data.easySolved +
+  data[i].data.mediumSolved * 3 +
+  data[i].data.hardSolved * 5;
+
+data[i].data.totalSolved =
+  data[i].data.easySolved +
+  data[i].data.mediumSolved +
+  data[i].data.hardSolved;
 
     if (periodName === "weekly" && data[i].data.totalSolved >= 7 && badgesMap) {
       checkHotStreak(data[i].id, DATA_DIR, badgesMap);


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and what problem it solves. -->

### Linked Issue

Fixes # (issue number)
#238 fixed

### Changes Made

<!-- Briefly describe the key changes made in this PR. -->
## Summary

This PR prevents negative period deltas in `processTimeframe()` by clamping
`easySolved`, `mediumSolved`, and `hardSolved` to a minimum of `0` using
`Math.max(0, ...)`.

## Changes

- Clamp `easySolved` delta to zero.
- Clamp `mediumSolved` delta to zero.
- Clamp `hardSolved` delta to zero.

This prevents negative solved counts and negative leaderboard scores when the
current cumulative totals are lower than the previous snapshot.

## Type of Change

<!-- Put an 'x' inside the brackets that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

<!-- Describe how you tested your changes -->

- [ ] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [ ] No console errors introduced

## Checklist

- [ ] My code follows the project's coding style
- [ ] I have formatted my code locally by running `npx prettier --write .` before submitting
- [ ] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [ ] I have linked the relevant issue

## Screenshots / Screen Recording

<!-- Required for UI/Visual changes whenever possible -->
