### PR TITLE
fix: render user-controlled names via textContent instead of innerHTM…

### DIFF
--- a/frontend/js/leaderboard/compare.js
+++ b/frontend/js/leaderboard/compare.js
@@ -231,19 +231,33 @@ function updateFloatingCompareBar() {
 
   bar.style.display = "flex";
 
-  const namesStr = window.selectedUsers.map((u) => u.name).join(", ");
   const count = window.selectedUsers.length;
 
+  // Static markup (no user-controlled data) is safe via innerHTML.
   bar.innerHTML = `
-    <div class="selected-list">
-      Comparing (<span class="selected-tag">${count}/3</span>): ${namesStr}
-    </div>
+    <div class="selected-list"></div>
     <div class="actions">
       <button id="floating-btn-compare" class="btn-compare" ${count < 2 ? "disabled" : ""}>Compare</button>
       <button id="floating-btn-clear" class="btn-clear">Clear</button>
       <button id="floating-btn-cancel" class="btn-clear" style="color: var(--amber);">Cancel</button>
     </div>
   `;
+
+  // Names are user-controlled, so build this part with safe DOM nodes
+  // (textContent) instead of interpolating into innerHTML.
+  const listDiv = bar.querySelector(".selected-list");
+  listDiv.appendChild(document.createTextNode("Comparing ("));
+  const tagSpan = document.createElement("span");
+  tagSpan.className = "selected-tag";
+  tagSpan.textContent = `${count}/3`;
+  listDiv.appendChild(tagSpan);
+  listDiv.appendChild(document.createTextNode("): "));
+  window.selectedUsers.forEach((u, idx) => {
+    listDiv.appendChild(document.createTextNode(u.name));
+    if (idx < window.selectedUsers.length - 1) {
+      listDiv.appendChild(document.createTextNode(", "));
+    }
+  });
 }
 
 /**
@@ -498,22 +512,34 @@ function populateComparisonTable() {
     });
   }
 
-  let html = "<thead><tr>";
+  table.innerHTML = "";
+
+  const thead = document.createElement("thead");
+  const headerRow = document.createElement("tr");
   headers.forEach((h) => {
-    html += `<th>${h}</th>`;
+    const th = document.createElement("th");
+    // Header may include user-controlled names (textContent only).
+    th.textContent = h;
+    headerRow.appendChild(th);
   });
-  html += "</tr></thead><tbody>";
+  thead.appendChild(headerRow);
 
+  const tbody = document.createElement("tbody");
   metrics.forEach((m) => {
-    html += `<tr><td>${m.label}</td>`;
+    const row = document.createElement("tr");
+    const labelCell = document.createElement("td");
+    labelCell.textContent = m.label;
+    row.appendChild(labelCell);
     m.values.forEach((v) => {
-      html += `<td>${v}</td>`;
+      const cell = document.createElement("td");
+      cell.textContent = v;
+      row.appendChild(cell);
     });
-    html += "</tr>";
+    tbody.appendChild(row);
   });
-  html += "</tbody>";
 
-  table.innerHTML = html;
+  table.appendChild(thead);
+  table.appendChild(tbody);
 }
 
 /**

--- a/frontend/js/leaderboard/sync-changes.js
+++ b/frontend/js/leaderboard/sync-changes.js
@@ -47,24 +47,63 @@ document.addEventListener("DOMContentLoaded", () => {
 
     btn.classList.add("pulse");
 
-    let html = "";
+    const fragment = document.createDocumentFragment();
+
     if (changes.rank_changes) {
       changes.rank_changes.forEach((rc) => {
         const arrow = rc.rank_delta > 0 ? "↑" : "↓";
         const color = rc.rank_delta > 0 ? "var(--green)" : "var(--red)";
-        html += `<div class="changes-content-line"><span style="color:${color}">${arrow}</span> <span><strong style="color:#fff;">${rc.username}</strong> moved #${rc.old_rank} → <strong style="color:var(--green)">#${rc.new_rank}</strong></span></div>`;
+
+        const line = document.createElement("div");
+        line.className = "changes-content-line";
+
+        const arrowSpan = document.createElement("span");
+        arrowSpan.style.color = color;
+        arrowSpan.textContent = arrow;
+        line.appendChild(arrowSpan);
+        line.appendChild(document.createTextNode(" "));
+
+        const detailSpan = document.createElement("span");
+        const nameStrong = document.createElement("strong");
+        nameStrong.style.color = "#fff";
+        // User-controlled display name (textContent only).
+        nameStrong.textContent = rc.username;
+        detailSpan.appendChild(nameStrong);
+        detailSpan.appendChild(
+          document.createTextNode(` moved #${rc.old_rank} → `),
+        );
+        const newRankStrong = document.createElement("strong");
+        newRankStrong.style.color = "var(--green)";
+        newRankStrong.textContent = `#${rc.new_rank}`;
+        detailSpan.appendChild(newRankStrong);
+
+        line.appendChild(detailSpan);
+        fragment.appendChild(line);
       });
     }
 
     if (changes.new_users && changes.new_users.length > 0) {
-      html += `<div class="changes-content-line"><span style="color:#fff;">${changes.new_users.length} new user(s) joined</span></div>`;
+      const line = document.createElement("div");
+      line.className = "changes-content-line";
+      const span = document.createElement("span");
+      span.style.color = "#fff";
+      span.textContent = `${changes.new_users.length} new user(s) joined`;
+      line.appendChild(span);
+      fragment.appendChild(line);
     }
 
     if (changes.total_new_solves && changes.total_new_solves > 0) {
-      html += `<div class="changes-content-line"><span style="color:#fff;">${changes.total_new_solves} new problems solved across ${changes.users_with_new_solves} users</span></div>`;
+      const line = document.createElement("div");
+      line.className = "changes-content-line";
+      const span = document.createElement("span");
+      span.style.color = "#fff";
+      span.textContent = `${changes.total_new_solves} new problems solved across ${changes.users_with_new_solves} users`;
+      line.appendChild(span);
+      fragment.appendChild(line);
     }
 
-    body.innerHTML = html;
+    body.innerHTML = "";
+    body.appendChild(fragment);
   }
 
   loadChanges();

--- a/frontend/registration.html
+++ b/frontend/registration.html
@@ -60,6 +60,7 @@
                 name="name"
                 class="form-input"
                 placeholder="Enter your full name"
+                maxlength="100"
                 required
               />
               <span class="error-msg" id="name-error"></span>


### PR DESCRIPTION
## Description

This PR fixes a DOM-based XSS vulnerability caused by rendering user-controlled display names with `innerHTML` in the leaderboard.

The vulnerable rendering paths have been replaced with safe DOM construction using `textContent`, `createTextNode`, and `createElement`, preventing HTML or JavaScript supplied through user names from being interpreted by the browser.

As a defense-in-depth measure, a `maxlength="100"` attribute has also been added to the Full Name field on the registration form.

### Linked Issue

Fixes #237

### Changes Made

* Replaced unsafe `innerHTML` interpolation in the floating compare bar with safe DOM node construction.
* Rebuilt the comparison table using `createElement` and `textContent` instead of generating HTML strings.
* Replaced dynamic HTML generation in the recent changes panel with safe DOM APIs and `DocumentFragment`.
* Added `maxlength="100"` to the registration form's Full Name field as an additional client-side safeguard.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] UI/Visual update
* [ ] Documentation update
* [ ] Refactor

## Testing

* [x] Tested locally
* [ ] Tested on mobile viewport (if applicable)
* [x] No console errors introduced

### Manual verification

Verified locally using HTML/JavaScript payloads such as:

* `<img src=x onerror=alert("XSS")>`
* `<script>alert("XSS")</script>`
* `<b>Bold User</b>`

Confirmed that these payloads are rendered as plain text (not interpreted as HTML) in:

* Floating compare bar
* Comparison table headers
* Recent changes modal

No JavaScript execution or alert dialogs occurred.

## Checklist

* [x] My code follows the project's coding style
* [x] I have formatted my code locally by running `npx prettier --write .` before submitting
* [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings or errors
* [ ] I have updated documentation if required
* [x] I have linked the relevant issue

## Screenshots
Not applicable.