### PR TITLE
fix: clamp period deltas at 0 in processTimeframe to prevent negative…

### DIFF
--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -278,9 +278,18 @@ async function processTimeframe(
       data.splice(i--, 1);
       continue;
     }
-    data[i].data.easySolved -= previousData[previousIndex].data.easySolved;
-    data[i].data.mediumSolved -= previousData[previousIndex].data.mediumSolved;
-    data[i].data.hardSolved -= previousData[previousIndex].data.hardSolved;
+    data[i].data.easySolved = Math.max(
+      0,
+      data[i].data.easySolved - previousData[previousIndex].data.easySolved,
+    );
+    data[i].data.mediumSolved = Math.max(
+      0,
+      data[i].data.mediumSolved - previousData[previousIndex].data.mediumSolved,
+    );
+    data[i].data.hardSolved = Math.max(
+      0,
+      data[i].data.hardSolved - previousData[previousIndex].data.hardSolved,
+    );
     data[i].score =
       data[i].data.easySolved +
       data[i].data.mediumSolved * 3 +


### PR DESCRIPTION
## Description

This PR fixes an issue where the daily, weekly, and monthly leaderboards could display **negative solved counts and negative scores** when a user's cumulative totals temporarily decreased (for example, due to an inconsistent API response).

`processTimeframe()` in `scripts/sync-leaderboard.js` previously calculated period deltas using direct subtraction, which could produce negative values. This change clamps the solved counts to a minimum of `0` using `Math.max(0, ...)` before recalculating the derived `score` and `totalSolved` values.

### Linked Issue

Fixes #238

### Changes Made

* Replaced direct subtraction with `Math.max(0, current - previous)` for:

  * `easySolved`
  * `mediumSolved`
  * `hardSolved`
* Left the existing `score` and `totalSolved` calculations unchanged so they automatically derive from the clamped values.
* Preserved the existing calculation flow while preventing invalid negative values from propagating to the leaderboard.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] UI/Visual update
* [ ] Documentation update
* [ ] Refactor

## Testing

* [x] Tested locally
* [ ] Tested on mobile viewport (if applicable)
* [x] No console errors introduced

### Manual Verification

Verified the logic using a scenario where a user's previous cumulative snapshot exceeded the current snapshot. Confirmed that:

* `easySolved`, `mediumSolved`, and `hardSolved` are clamped to `0` instead of becoming negative.
* `score` is recalculated from the clamped values and never becomes negative.
* `totalSolved` is derived from the corrected solved counts and remains non-negative.

No automated tests were added since this repository does not currently include a test suite for the leaderboard sync scripts.

## Checklist

* [x] My code follows the project's coding style
* [x] I have formatted my code locally by running `npx prettier --write .` before submitting
* [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings or errors
* [ ] I have updated documentation if required
* [x] I have linked the relevant issue

## Screenshots / Screen Recording

N/A – Backend data-processing change only. No UI or visual changes.