### PR TITLE
feat: include contest data in user info API response

### DIFF
--- a/scripts/fetch-user-info.js
+++ b/scripts/fetch-user-info.js
@@ -7,6 +7,7 @@ async function fetchUserInfo(username) {
   let history = [];
   let ranking = null;
   let badges = [];
+  let contest = null;
 
   const liveApiUrl = `https://leetcode-api-dun.vercel.app/${username}`;
   const cacheBuster = Date.now();
@@ -17,6 +18,7 @@ async function fetchUserInfo(username) {
       if (res.ok) {
         const apiData = await res.json();
         ranking = apiData.ranking || 0;
+        contest = apiData.contest || null;
       }
     })
     .catch((err) =>
@@ -57,6 +59,7 @@ async function fetchUserInfo(username) {
     username,
     ranking,
     badges,
+    contest,
     history,
   };
 }


### PR DESCRIPTION
## Description

This PR extends the `fetchUserInfo` utility function to capture and return the complete contest data object from the upstream LeetCode API wrapper. This allows the backend to expose competitive programming metrics (such as contest rating, global ranking, badges, and percentiles) via the `/api/user/:username` endpoint, setting up the required data foundation for the frontend profile update.

### Linked Issue

Fixes #192 

### Changes Made

* Updated `fetch-user-info.js` to initialize and extract the `contest` data object from `liveApiUrl`.
* Appended the `contest` object to the final returned payload of the `fetchUserInfo` function.
* Added fallback handling (`|| null`) to ensure graceful execution for users with no contest history.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

* Tested locally by starting the server and hitting the `/api/user/:username` route with an active contest participant's username. Verified that the JSON response now completely returns the nested `contest` structure containing rating, rank, total participants, top percentage, count, and badge.

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording
<img width="467" height="473" alt="Screenshot 2026-06-27 141933" src="https://github.com/user-attachments/assets/23c0775b-ef44-44de-94b5-2d94d35cfee3" />


