### PR TITLE
fix: pass reaction-token to slash-command-dispatch and clean up workf…

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -1,10 +1,5 @@
 name: format-command
 
-# This workflow no longer triggers on issue_comment directly. It only runs
-# after .github/workflows/slash-command-dispatch.yml has verified that the
-# commenter has write access to the repository and created a
-# "format-command" repository_dispatch event. This removes the unauthenticated
-# pwn-request path: untrusted commenters never reach this job.
 on:
   repository_dispatch:
     types: [format-command]
@@ -48,7 +43,7 @@ jobs:
               issue_number: context.payload.client_payload.github.payload.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "I have successfully run Prettier and pushed the formatting fixes to this PR.\n\n**Note for Contributors:** Because this commit was pushed by a bot, GitHub will not automatically re-run the CI checks. To trigger them to pass, you must either:\n- Push an empty commit locally (`git commit --allow-empty -m \"Trigger builds\"` and push)\n- Close and immediately reopen this Pull Request."
+              body: "I have successfully run Prettier and pushed the formatting fixes to this PR.\n\n**Note:** Since this commit was pushed by a bot, GitHub will not automatically re-run the CI checks. To trigger them, either:\n- Push an empty commit (`git commit --allow-empty -m \"Trigger builds\"` and push)\n- Close and immediately reopen this Pull Request."
             })
 
       - name: Post failure comment

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -8,14 +8,11 @@ jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest
     steps:
-      # peter-evans/slash-command-dispatch checks the commenter's repository
-      # permission (default: "write") BEFORE any dispatch event is created.
-      # No PR/fork code is checked out in this job, so untrusted commenters
-      # can never reach a step that holds write-scoped credentials.
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v5
         with:
           token: ${{ secrets.PAT }}
+          reaction-token: ${{ secrets.PAT }}
           commands: format
           permission: write
           issue-type: pull-request


### PR DESCRIPTION
## Description
Follow-up to #250, addressing feedback on #236.

- Adds `reaction-token: ${{ secrets.PAT }}` to `slash-command-dispatch.yml`. The action's own job log on the test PR shows explicit `Failed to set reaction on comment` annotations under the current workflow, passing a token with write-scoped credentials for reactions resolves that documented failure mode, using the same `PAT` already configured for dispatching.
- Removes the explanatory comments from both workflow files per request, since they're not needed in production.
- Updates the post-format completion message in `format-command.yml`, it previously said "Note for Contributors," but since `/format` is now restricted to maintainers/collaborators, that audience framing was outdated.

### Linked Issue
Relates to #236

### Changes Made
- `slash-command-dispatch.yml`: added `reaction-token` input; removed explanatory comment block.
- `format-command.yml`: removed explanatory comment block; reworded the bot's push-completion comment to drop "for Contributors," since the audience triggering `/format` is now maintainers/collaborators only.

## Type of Change
<!-- Put an 'x' inside the brackets that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing
<!-- Describe how you tested your changes -->
- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

Validated both workflow files with `actionlint` (no errors) and `prettier --check`.

## Checklist
- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required <!-- handled separately in a dedicated docs PR per maintainer's request -->
- [x] I have linked the relevant issue

## Screenshots / Screen Recording
<!-- Required for UI/Visual changes whenever possible -->
N/A , CI/workflow-only change with no UI impact.