### PR TITLE
docs: clarify /format command is collaborator-only

### DIFF
--- a/.github/workflows/contributor-reminder.yml
+++ b/.github/workflows/contributor-reminder.yml
@@ -35,5 +35,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "Thank you for submitting a pull request.\n\nPlease ensure your changes comply with the project's contribution guidelines and that all workflow checks pass successfully.\n\n### Formatting and Branching\n- Please confirm you have formatted your code locally using `npx prettier --write .`, or you can simply comment `/format` on this PR to have our bot do it for you!\n- Ensure this PR is made from a `feature/*` branch and not `main`.\n\n> **Note:** This project is currently maintained by a solo maintainer, so reviews and responses may sometimes take a little time. Thanks for your patience."
+              body: "Thank you for submitting a pull request.\n\nPlease ensure your changes comply with the project's contribution guidelines and that all workflow checks pass successfully.\n\n### Formatting and Branching\n- Please confirm you have formatted your code locally using `npx prettier --write .` before requesting a review.\n- Ensure this PR is made from a `feature/*` branch and not `main`.\n\n> **Note:** This project is currently maintained by a solo maintainer, so reviews and responses may sometimes take a little time. Thanks for your patience."
             })

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Before submitting your Pull Request, please run the following command in the roo
 npx prettier --write .
 ```
 
-Alternatively, you can comment `/format` on your Pull Request, and our GitHub Actions bot will automatically format your code and push the commit for you.
+For security reasons, the `/format` PR comment command can only be triggered by maintainers/collaborators — if you're an external contributor, please run Prettier locally as shown above before requesting a review.
 
 ### Frontend Changes
 


### PR DESCRIPTION
## Description
Documentation follow-up to #236/#250, updates contributor-facing docs and bot messages to reflect that the `/format` PR command is now restricted to maintainers/collaborators, not something any contributor can trigger.

### Changes Made
- `CONTRIBUTING.md`: clarifies that external contributors should run Prettier locally; `/format` is for maintainers/collaborators only.
- `contributor-reminder.yml`: removed the line inviting contributors to comment `/format`, since that auto-comment is shown to non-maintainers who can't use it.

### Linked Issue
Relates to #236

## Type of Change
<!-- Put an 'x' inside the brackets that apply -->
- [ ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [x] Documentation update
- [ ] Refactor

## Testing
<!-- Describe how you tested your changes -->
- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

Validated both files with `prettier --check`. Confirmed via repo-wide grep that no other docs or workflow messages still reference contributors using `/format`.

## Checklist
- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording
<!-- Required for UI/Visual changes whenever possible -->
N/A, documentation/messaging change only, no UI impact.