### PR TITLE
fix: footer responsive layout on mobile

### DIFF
--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -1864,7 +1864,7 @@ body::-webkit-scrollbar-thumb {
 /* Footer responsive */
 @media (max-width: 900px) {
   .footer-container {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr;
     gap: 28px;
     text-align: center;
   }
@@ -1883,7 +1883,7 @@ body::-webkit-scrollbar-thumb {
   .footer-section:nth-child(2),
   .footer-section:nth-child(3),
   .footer-section:nth-child(4) {
-    grid-column: 1 / -1;
+    grid-column: unset;
     justify-self: center;
   }
 }

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -1881,10 +1881,20 @@ body::-webkit-scrollbar-thumb {
   }
 
   .footer-section:nth-child(2),
-  .footer-section:nth-child(3),
-  .footer-section:nth-child(4) {
+  .footer-section:nth-child(3) {
     grid-column: unset;
     justify-self: center;
+  }
+
+  .footer-section:nth-child(4) {
+    grid-column: 1 / -1;
+    justify-self: center;
+  }
+}
+
+@media (max-width: 360px) {
+  .footer-container {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -2829,6 +2839,7 @@ body::-webkit-scrollbar-thumb {
   font-weight: 600;
   margin-left: 4px;
 }
+
 .rank-change[data-tooltip]::before {
   content: attr(data-tooltip);
   position: absolute;
@@ -2850,9 +2861,11 @@ body::-webkit-scrollbar-thumb {
   transition: opacity 0.15s ease-in-out;
   box-shadow: 0 0 15px rgba(0, 255, 65, 0.2);
 }
+
 .rank-change[data-tooltip]:hover::before {
   opacity: 1;
 }
+
 @media (max-width: 480px) {
   .rank-change[data-tooltip]::before {
     bottom: auto;
@@ -2948,6 +2961,7 @@ input[type="checkbox"].compare-checkbox:checked::after {
     transform: translate(-50%, 100px);
     opacity: 0;
   }
+
   to {
     transform: translate(-50%, 0);
     opacity: 1;
@@ -3187,6 +3201,7 @@ input[type="checkbox"].compare-checkbox:checked::after {
     transform: translateX(120%);
     opacity: 0;
   }
+
   to {
     transform: translateX(0);
     opacity: 1;
@@ -3197,6 +3212,7 @@ input[type="checkbox"].compare-checkbox:checked::after {
   .compare-charts-row {
     flex-direction: column;
   }
+
   .compare-chart-card {
     height: 300px;
   }


### PR DESCRIPTION
## Description

Fixed footer layout breaking into a single sequential column on mobile viewports. Footer sections now display in a 2-column parallel grid on small screens.

### Linked Issue

Fixes #248

### Changes Made

- Changed \`.footer-container\` from \`grid-template-columns: 1fr\` to \`1fr 1fr\` at max-width 900px
- Removed \`grid-column: 1 / -1\` override on footer link sections, replaced with \`unset\`

## Type of Change

- [x] Bug fix
- [x] UI/Visual update

## Testing

- [x] Tested locally
- [x] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I am submitting my PR from a dedicated \`feature/*\` branch, not the \`main\` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have linked the relevant issue