### PR TITLE
feat: Implement API Caching, Resilient Request Retries, and Error Backoff (#219)

### DIFF
--- a/scripts/fetch-user-info.js
+++ b/scripts/fetch-user-info.js
@@ -50,16 +50,15 @@ async function fetchUserInfo(username) {
   }
 
   // 2. Fetch live profile ranking from the wrapper API
-  const livePromise = fetch(liveApiUrl)
-    .then(async (res) => {
-      if (res.ok) {
-        const apiData = await res.json();
-        ranking = apiData.ranking || 0;
-        contest = apiData.contest || null;
-      } else {
-        throw new Error(`LeetCode API wrapper returned status ${res.status}`);
-      }
-    });
+  const livePromise = fetch(liveApiUrl).then(async (res) => {
+    if (res.ok) {
+      const apiData = await res.json();
+      ranking = apiData.ranking || 0;
+      contest = apiData.contest || null;
+    } else {
+      throw new Error(`LeetCode API wrapper returned status ${res.status}`);
+    }
+  });
 
   // Wait for the live API task to complete
   await livePromise;

--- a/scripts/fetch-user-info.js
+++ b/scripts/fetch-user-info.js
@@ -56,17 +56,13 @@ async function fetchUserInfo(username) {
         const apiData = await res.json();
         ranking = apiData.ranking || 0;
         contest = apiData.contest || null;
+      } else {
+        throw new Error(`LeetCode API wrapper returned status ${res.status}`);
       }
-    })
-    .catch((err) =>
-      console.error(
-        "Failed to fetch live profile ranking from API wrapper:",
-        err.message,
-      ),
-    );
+    });
 
-  // Wait for the concurrent live API task to complete
-  await Promise.allSettled([livePromise]);
+  // Wait for the live API task to complete
+  await livePromise;
 
   // Ensure history is sorted chronologically
   history.sort((a, b) => new Date(a.date) - new Date(b.date));

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -4,6 +4,56 @@ const axios = require("axios");
 const fs = require("fs");
 const path = require("path");
 
+// Configure retry settings on axios response
+const MAX_RETRIES = 3;
+const INITIAL_DELAY_MS = 1000;
+
+axios.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const { config } = error;
+
+    if (!config) {
+      return Promise.reject(error);
+    }
+
+    config.__retryCount = config.__retryCount || 0;
+
+    const isRateLimited = error.response && error.response.status === 429;
+    const isServerError =
+      error.response &&
+      error.response.status >= 500 &&
+      error.response.status <= 599;
+    const isNetworkError =
+      !error.response ||
+      error.code === "ECONNABORTED" ||
+      error.message.includes("timeout");
+
+    const shouldRetry =
+      (isRateLimited || isServerError || isNetworkError) &&
+      config.__retryCount < MAX_RETRIES;
+
+    if (shouldRetry) {
+      config.__retryCount += 1;
+
+      // Exponential backoff with jitter
+      const backoffDelay =
+        INITIAL_DELAY_MS * Math.pow(2, config.__retryCount - 1);
+      const jitter = Math.random() * 200;
+      const delay = backoffDelay + jitter;
+
+      console.warn(
+        `[Retry ${config.__retryCount}/${MAX_RETRIES}] Request failed for ${config.url} (${error.message}). Retrying in ${Math.round(delay)}ms...`,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      return axios(config);
+    }
+
+    return Promise.reject(error);
+  },
+);
+
 function atomicWrite(filePath, data) {
   const dir = path.dirname(filePath);
   const ext = path.extname(filePath);

--- a/server.js
+++ b/server.js
@@ -142,6 +142,22 @@ const apiLimiter = rateLimit({
   },
 });
 
+// ---- Cache configuration ----
+const userCache = new Map();
+const CACHE_TTL_MS = 2 * 60 * 1000; // 2 minutes
+
+// Helper to prune cache to bound memory usage
+function pruneUserCache() {
+  if (userCache.size > 1000) {
+    const now = Date.now();
+    for (const [key, value] of userCache.entries()) {
+      if (now - value.timestamp > CACHE_TTL_MS) {
+        userCache.delete(key);
+      }
+    }
+  }
+}
+
 app.use("/api/user/:username", apiLimiter);
 
 app.get("/api/user/:username", async (req, res) => {
@@ -152,12 +168,36 @@ app.get("/api/user/:username", async (req, res) => {
     return res.status(400).json({ error: "Invalid username format" });
   }
 
+  const cached = userCache.get(username);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+    console.log(`[Cache Hit] Serving cached data for user: ${username}`);
+    return res.json(cached.data);
+  }
+
   try {
+    console.log(`[Cache Miss] Fetching fresh data for user: ${username}`);
     const data = await fetchUserInfo(username);
+
+    pruneUserCache();
+    userCache.set(username, {
+      timestamp: Date.now(),
+      data,
+    });
+
     res.json(data);
   } catch (err) {
-    res.status(500).json({
-      error: "Failed to fetch user details",
+    if (cached) {
+      console.warn(
+        `[Cache Fallback] Failed to fetch fresh data for user: ${username}. Serving stale cached data. Error: ${err.message}`,
+      );
+      return res.json(cached.data);
+    }
+
+    console.error(
+      `[Cache Error] Failed to fetch data for user: ${username} (No cached fallback available). Error: ${err.message}`,
+    );
+    res.status(502).json({
+      error: "Failed to fetch user details from external LeetCode API wrapper",
       details: err.message,
     });
   }

--- a/server.js
+++ b/server.js
@@ -175,14 +175,16 @@ app.get("/api/user/:username", async (req, res) => {
     if (now - cached.timestamp < CACHE_TTL_MS && cached.data) {
       return res.json(cached.data);
     }
-    
+
     if (cached.promise) {
       try {
         const data = await cached.promise;
         return res.json(data);
       } catch (err) {
         if (cached.data) {
-          console.warn(`[Cache Fallback] Serving stale data after pending fetch failed...`);
+          console.warn(
+            `[Cache Fallback] Serving stale data after pending fetch failed...`,
+          );
           return res.json(cached.data);
         }
       }
@@ -192,11 +194,11 @@ app.get("/api/user/:username", async (req, res) => {
   let fetchPromise;
   try {
     fetchPromise = fetchUserInfo(username);
-    
+
     userCache.set(username, {
       ...cached,
-      timestamp: cached ? cached.timestamp : 0, 
-      promise: fetchPromise
+      timestamp: cached ? cached.timestamp : 0,
+      promise: fetchPromise,
     });
 
     const data = await fetchPromise;
@@ -205,14 +207,14 @@ app.get("/api/user/:username", async (req, res) => {
     userCache.set(username, {
       timestamp: Date.now(),
       data,
-      promise: null
+      promise: null,
     });
 
     res.json(data);
   } catch (err) {
     userCache.set(username, {
       ...cached,
-      promise: null
+      promise: null,
     });
 
     if (cached && cached.data) {

--- a/server.js
+++ b/server.js
@@ -169,24 +169,53 @@ app.get("/api/user/:username", async (req, res) => {
   }
 
   const cached = userCache.get(username);
-  if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
-    console.log(`[Cache Hit] Serving cached data for user: ${username}`);
-    return res.json(cached.data);
+  const now = Date.now();
+
+  if (cached) {
+    if (now - cached.timestamp < CACHE_TTL_MS && cached.data) {
+      return res.json(cached.data);
+    }
+    
+    if (cached.promise) {
+      try {
+        const data = await cached.promise;
+        return res.json(data);
+      } catch (err) {
+        if (cached.data) {
+          console.warn(`[Cache Fallback] Serving stale data after pending fetch failed...`);
+          return res.json(cached.data);
+        }
+      }
+    }
   }
 
+  let fetchPromise;
   try {
-    console.log(`[Cache Miss] Fetching fresh data for user: ${username}`);
-    const data = await fetchUserInfo(username);
+    fetchPromise = fetchUserInfo(username);
+    
+    userCache.set(username, {
+      ...cached,
+      timestamp: cached ? cached.timestamp : 0, 
+      promise: fetchPromise
+    });
+
+    const data = await fetchPromise;
 
     pruneUserCache();
     userCache.set(username, {
       timestamp: Date.now(),
       data,
+      promise: null
     });
 
     res.json(data);
   } catch (err) {
-    if (cached) {
+    userCache.set(username, {
+      ...cached,
+      promise: null
+    });
+
+    if (cached && cached.data) {
       console.warn(
         `[Cache Fallback] Failed to fetch fresh data for user: ${username}. Serving stale cached data. Error: ${err.message}`,
       );


### PR DESCRIPTION
## Description

This PR implements caching for the `/api/user/:username` endpoint to reduce response times and unnecessary outbound queries to the external LeetCode API wrapper. It also implements robust request retries with exponential backoff and randomized jitter inside the daily synchronization script to safeguard against rate limits (HTTP 429) or transient server errors. Lastly, it ensures that downstream API failures are handled gracefully, logging the errors and returning a clean JSON error response (or falling back to expired cached data if available).

### Linked Issue

Fixes #219

### Changes Made

- **`scripts/fetch-user-info.js`**: Updated the live API fetch logic to propagate network/status errors instead of swallowing them internally.
- **`server.js`**: Added a 2-minute TTL in-memory cache system (using a JS `Map` with self-pruning). Modified the `/api/user/:username` endpoint to utilize the cache, serve stale cache entries as a fallback when the downstream API fails, and return a graceful JSON `502 Bad Gateway` payload if no cache exists.
- **`scripts/sync-leaderboard.js`**: Configured a global `axios` response interceptor to handle rate limiting (429), server errors (5xx), and timeout errors, retrying up to 3 times using exponential backoff and jitter.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

*(None required - backend/script logic changes)*
