### PR TITLE
fix: guard against malformed/non-array history data in fetchUserInfo

### DIFF
--- a/scripts/fetch-user-info.js
+++ b/scripts/fetch-user-info.js
@@ -29,7 +29,7 @@ async function fetchUserInfo(username) {
       // Auto-Migration Check & Routing
       if (Array.isArray(data)) {
         history = data;
-      } else {
+      } else if (data && typeof data === "object") {
         // Safe object destructuring for the new profile structure
         history = data.history || [];
         badges = data.badges || [];
@@ -69,6 +69,8 @@ async function fetchUserInfo(username) {
   await Promise.allSettled([livePromise]);
 
   // Ensure history is sorted chronologically
+  // Guard against a corrupted history file (e.g. non-array `history` field)
+  history = Array.isArray(history) ? history : [];
   history.sort((a, b) => new Date(a.date) - new Date(b.date));
 
   return {


### PR DESCRIPTION
## Description

Fixes a crash in `fetch-user-info.js` when historical user data is malformed. The endpoint now gracefully falls back to an empty history array instead of throwing an error when the fetched JSON is `null` or contains a non-array `history` field.

### Linked Issue

Fixes #239 

### Changes Made

* Added a null/object check before accessing migrated profile fields.
* Added a defensive `Array.isArray(history)` guard before sorting historical data.
* Preserved the existing migration logic for both legacy array-based and new object-based profile formats.
* Prevented `history.sort()` from throwing when malformed history data is encountered.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] UI/Visual update
* [ ] Documentation update
* [ ] Refactor

## Testing

* [x] Tested locally
* [ ] Tested on mobile viewport (if applicable)
* [x] No console errors introduced

### Test Cases

Verified the following scenarios locally:

* Valid legacy history array
* Valid object-based profile structure
* Empty object (`{}`)
* `null`
* `{ "history": "corrupted" }`
* `{ "history": {} }`

Confirmed that malformed history data now degrades gracefully to an empty history array instead of causing the `/api/user/:username` endpoint to fail.

## Checklist

* [x] My code follows the project's coding style
* [x] I have formatted my code locally by running `npx prettier --write .` before submitting
* [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings or errors
* [ ] I have updated documentation if required
* [x] I have linked the relevant issue

## Screenshots / Screen Recording

N/A, Backend robustness fix with no UI changes.
