### PR TITLE
feat: conditionally render user profile badges from API

### DIFF
--- a/frontend/js/user/badges.js
+++ b/frontend/js/user/badges.js
@@ -1,0 +1,43 @@
+async function loadBadges(username) {
+  const badgeWall = document.getElementById("badge-wall");
+  if (!badgeWall) return;
+
+  badgeWall.innerHTML = ""; 
+
+  try {
+    const res = await fetch(`/api/user/${username}`);
+    if (!res.ok) throw new Error("API response error");
+    
+    const data = await res.json();
+    const earnedBadges = data.badges || [];
+
+    if (earnedBadges.length === 0) {
+      return; 
+    }
+
+    earnedBadges.forEach(type => {
+      const badge = document.createElement("div");
+      
+      badge.className = `badge badge-${type.toLowerCase().replace('_', '')}`;
+      badge.textContent = `[${type}]`;
+      
+      if (type === 'HOT_STREAK') badge.setAttribute("data-title", "Solved >= 1 problem every day for 7 days");
+      if (type === 'SPEEDRUN') badge.setAttribute("data-title", "Top 3 problem-solving velocity this week");
+      if (type === 'UP_LINK') badge.setAttribute("data-title", "Jumped 5+ positions in ranks");
+
+      badgeWall.appendChild(badge);
+    });
+
+  } catch (err) {
+    console.error("Error loading user badges:", err);
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const pathSegments = window.location.pathname.split('/');
+  const username = pathSegments[pathSegments.length - 1] || pathSegments[pathSegments.length - 2];
+
+  if (username) {
+    loadBadges(username);
+  }
+});

--- a/frontend/js/user/badges.js
+++ b/frontend/js/user/badges.js
@@ -2,40 +2,50 @@ async function loadBadges(username) {
   const badgeWall = document.getElementById("badge-wall");
   if (!badgeWall) return;
 
-  badgeWall.innerHTML = ""; 
+  badgeWall.innerHTML = "";
 
   try {
     const res = await fetch(`/api/user/${username}`);
     if (!res.ok) throw new Error("API response error");
-    
+
     const data = await res.json();
     const earnedBadges = data.badges || [];
 
     if (earnedBadges.length === 0) {
-      return; 
+      return;
     }
 
-    earnedBadges.forEach(type => {
+    earnedBadges.forEach((type) => {
       const badge = document.createElement("div");
-      
-      badge.className = `badge badge-${type.toLowerCase().replace('_', '')}`;
+
+      badge.className = `badge badge-${type.toLowerCase().replace("_", "")}`;
       badge.textContent = `[${type}]`;
-      
-      if (type === 'HOT_STREAK') badge.setAttribute("data-title", "Solved >= 1 problem every day for 7 days");
-      if (type === 'SPEEDRUN') badge.setAttribute("data-title", "Top 3 problem-solving velocity this week");
-      if (type === 'UP_LINK') badge.setAttribute("data-title", "Jumped 5+ positions in ranks");
+
+      if (type === "HOT_STREAK")
+        badge.setAttribute(
+          "data-title",
+          "Solved >= 1 problem every day for 7 days",
+        );
+      if (type === "SPEEDRUN")
+        badge.setAttribute(
+          "data-title",
+          "Top 3 problem-solving velocity this week",
+        );
+      if (type === "UP_LINK")
+        badge.setAttribute("data-title", "Jumped 5+ positions in ranks");
 
       badgeWall.appendChild(badge);
     });
-
   } catch (err) {
     console.error("Error loading user badges:", err);
   }
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-  const pathSegments = window.location.pathname.split('/');
-  const username = pathSegments[pathSegments.length - 1] || pathSegments[pathSegments.length - 2];
+  const pathSegments = window.location.pathname.split("/");
+  const username =
+    pathSegments[pathSegments.length - 1] ||
+    pathSegments[pathSegments.length - 2];
 
   if (username) {
     loadBadges(username);

--- a/frontend/user.html
+++ b/frontend/user.html
@@ -570,6 +570,7 @@
     </main>
 
     <script nonce="__NONCE__" src="/js/user/historical-graphs.js"></script>
+    <script src="/js/user/badges.js"></script>
     <script src="/js/footer.js"></script>
     <script src="/js/matrix.js"></script>
     <script src="/js/terminal_ui.js"></script>


### PR DESCRIPTION
## Description

This PR updates the user profile page (`[USER_PROFILE]`) to dynamically fetch and render earned badges instead of displaying hardcoded HTML placeholders. It clears out the static badge elements on load and loops through the dynamic payload array returned by the backend API (`/api/user/:username`) to inject only the badges the student has earned. If no badges are returned, the container is gracefully left empty.

### Linked Issue

Fixes #197 

### Changes Made

- Created a dedicated frontend script `/js/user/badges.js` to handle fetching and rendering profiles.
- Added extraction logic to grab the current user's username from the active URL pathname.
- Added `loadBadges` logic to map specific badge codes (`HOT_STREAK`, `SPEEDRUN`, `UP_LINK`) to their respective container styling classes and hovering `data-title` tooltips.
- Cleared out the hardcoded elements inside `#badge-wall` inside the profile HTML template.
- Connected the new script at the bottom of the profile HTML document.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [x] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording
<img width="1258" height="575" alt="Screenshot 2026-06-30 130339" src="https://github.com/user-attachments/assets/85e347d8-4f0f-4269-9148-710725f0b365" />
