### PR TITLE
perf: implement in-memory HTML caching to minimize disk I/O

### DIFF
--- a/server.js
+++ b/server.js
@@ -79,11 +79,18 @@ app.use((req, res, next) => {
 });
 
 // 4. HTML page routes — inject per-request nonce into __NONCE__ placeholders
+const htmlCache = {};
 function serveHtml(res, filePath) {
+  if (htmlCache[filePath]) {
+    const html = htmlCache[filePath].replace(/__NONCE__/g, res.locals.nonce);
+    return res.type("html").send(html);
+  }
+
   fs.readFile(filePath, "utf8", (err, data) => {
     if (err) {
       return res.status(500).send("Error loading page");
     }
+    htmlCache[filePath] = data;
     const html = data.replace(/__NONCE__/g, res.locals.nonce);
     res.type("html").send(html);
   });


### PR DESCRIPTION
## Description

This PR introduces an optimization to the HTML serving process by caching raw HTML templates in an in-memory dictionary (`htmlCache`) upon the first read. Subsequent page requests are served directly out of server RAM instead of hitting the filesystem continuously. 

### Linked Issue

Fixes #243 

### Changes Made

- Introduced a global `htmlCache` object container to store raw file strings.
- Refactored `serveHtml()` to check for existing file keys within `htmlCache` prior to running filesystem utilities.
- Kept the cryptographic nonce token replacement (`/__NONCE__/g`) real-time and distinct on each client transaction to preserve Content Security Policy (CSP) integrity.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor / Performance Optimization

## Testing

- [x] Tested locally (routes resolve perfectly)
- [x] Verified cryptographic nonces regenerate successfully on each page reload
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording