### PR TITLE
fix(sync): fallback to historyMap on API fetch failure (#263)

### DIFF
--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -478,6 +478,12 @@ async function processTimeframe(
 
         const data = await fetchData(baseUrl + user.id);
         if (!data) {
+          const cache = historyMap.get(user.id);
+          if (cache) {
+            console.log(`${user.name}: recycled (API error fallback)`);
+            overallData.push(cache);
+            return;
+          }
           console.log(`${user.name}: skipped (API error)`);
           return;
         }


### PR DESCRIPTION
## Description

This PR resolves issue #263 where active users were being dropped entirely from the leaderboard when external API wrapper fetches failed (due to rate limiting, network timeouts, or DNS failures).

### Linked Issue

Fixes #263

### Changes Made

- Updated the daily fetch loop in `scripts/sync-leaderboard.js` to look up the user's cached records from `historyMap` when `fetchData` fails instead of logging and returning prematurely.
- Recycles the user's last known stats (`easySolved`, `mediumSolved`, `hardSolved`, `score`, etc.) if available.
- Skips the user only if no historical cached record is available.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

*Note: Tested using a mock environment by simulating API timeouts/rate-limit failures for test users and verifying that the daily sync recycled their previous overall data and scores correctly without dropping them.*

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue
