### PR TITLE
fix(frontend): adjust pagination totalPages and currentPage to respect search filters (#262)

### DIFF
--- a/frontend/js/leaderboard/pagination.js
+++ b/frontend/js/leaderboard/pagination.js
@@ -23,6 +23,13 @@ function renderPagination(totalItems) {
 
   if (!pageNumbers) return;
 
+  const isSearching =
+    typeof currentSearchTerm !== "undefined" && currentSearchTerm.length > 0;
+  if (isSearching) {
+    pageNumbers.innerHTML = "";
+    return;
+  }
+
   const totalPages = Math.ceil(totalItems / itemsPerPage);
   pageNumbers.innerHTML = "";
 

--- a/frontend/js/leaderboard/pagination.js
+++ b/frontend/js/leaderboard/pagination.js
@@ -8,9 +8,7 @@ function setupPaginationListeners() {
   });
 
   document.getElementById("next-page-btn")?.addEventListener("click", () => {
-    const totalPages = Math.ceil(
-      leaderboardData[activeDatasetType].length / itemsPerPage,
-    );
+    const totalPages = window.totalPages || 1;
 
     if (currentPage < totalPages) {
       currentPage++;

--- a/frontend/js/leaderboard/search.js
+++ b/frontend/js/leaderboard/search.js
@@ -18,6 +18,7 @@ function setupSearchListeners() {
 
       clearBtn.style.display = e.target.value.trim() !== "" ? "flex" : "none";
 
+      currentPage = 1;
       applyFiltersAndRender();
     }, 300),
   );
@@ -29,6 +30,7 @@ function setupSearchListeners() {
     clearBtn.style.display = "none";
 
     searchInput.focus();
+    currentPage = 1;
     applyFiltersAndRender();
   });
 
@@ -53,6 +55,7 @@ function setupSearchListeners() {
       currentSearchTerm = "";
       clearBtn.style.display = "none";
       searchInput.blur();
+      currentPage = 1;
       applyFiltersAndRender();
     }
   });

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -557,6 +557,7 @@
         );
 
         const totalPages = Math.ceil(renderableData.length / itemsPerPage) || 1;
+        window.totalPages = totalPages;
         document.getElementById("prev-page-btn").disabled = currentPage === 1;
         document.getElementById("next-page-btn").disabled =
           currentPage === totalPages;

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -556,38 +556,63 @@
           (user) => user && !zeroScoreUserIds.has(user.id),
         );
 
-        const totalPages = Math.ceil(renderableData.length / itemsPerPage) || 1;
-        window.totalPages = totalPages;
-        document.getElementById("prev-page-btn").disabled = currentPage === 1;
-        document.getElementById("next-page-btn").disabled =
-          currentPage === totalPages;
-
+        const isSearching = currentSearchTerm.length > 0;
         const statsEl = document.getElementById("leaderboard-stats");
 
-        const startRow =
-          renderableData.length === 0
-            ? 0
-            : (currentPage - 1) * itemsPerPage + 1;
+        if (isSearching) {
+          document.getElementById("prev-page-btn").disabled = true;
+          document.getElementById("next-page-btn").disabled = true;
+          window.totalPages = 1;
 
-        const endRow = Math.min(
-          currentPage * itemsPerPage,
-          renderableData.length,
-        );
+          const totalMatched = filteredData.length;
+          const startRow = totalMatched === 0 ? 0 : 1;
+          const endRow = totalMatched;
 
-        statsEl.innerHTML = `
-            <div style="
-              text-align:center;
-              color:var(--text-dim);
-              margin-bottom:1rem;
-              font-family:'Fira Code', monospace;
-            ">
-              Total Users: ${filteredData.length}
-              | Showing: ${startRow}-${endRow}
-              | Page: ${currentPage}/${totalPages}
-            </div>
-          `;
+          statsEl.innerHTML = `
+              <div style="
+                text-align:center;
+                color:var(--text-dim);
+                margin-bottom:1rem;
+                font-family:'Fira Code', monospace;
+              ">
+                Total Users: ${totalMatched}
+                | Showing: ${startRow}-${endRow}
+                | Page: 1/1
+              </div>
+            `;
+        } else {
+          const totalPages =
+            Math.ceil(renderableData.length / itemsPerPage) || 1;
+          window.totalPages = totalPages;
+          document.getElementById("prev-page-btn").disabled = currentPage === 1;
+          document.getElementById("next-page-btn").disabled =
+            currentPage === totalPages;
 
-        renderLeaderboard(filteredData, zeroScoreUserIds, totalPages);
+          const startRow =
+            renderableData.length === 0
+              ? 0
+              : (currentPage - 1) * itemsPerPage + 1;
+
+          const endRow = Math.min(
+            currentPage * itemsPerPage,
+            renderableData.length,
+          );
+
+          statsEl.innerHTML = `
+              <div style="
+                text-align:center;
+                color:var(--text-dim);
+                margin-bottom:1rem;
+                font-family:'Fira Code', monospace;
+              ">
+                Total Users: ${renderableData.length}
+                | Showing: ${startRow}-${endRow}
+                | Page: ${currentPage}/${totalPages}
+              </div>
+            `;
+        }
+
+        renderLeaderboard(filteredData, zeroScoreUserIds, window.totalPages);
       }
 
       function renderLeaderboard(data, zeroScoreUserIds, totalPages) {

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -593,10 +593,10 @@
               ? 0
               : (currentPage - 1) * itemsPerPage + 1;
 
-          const endRow = Math.min(
-            currentPage * itemsPerPage,
-            renderableData.length,
-          );
+          const endRow =
+            currentPage === totalPages
+              ? filteredData.length
+              : currentPage * itemsPerPage;
 
           statsEl.innerHTML = `
               <div style="
@@ -605,7 +605,7 @@
                 margin-bottom:1rem;
                 font-family:'Fira Code', monospace;
               ">
-                Total Users: ${renderableData.length}
+                Total Users: ${filteredData.length}
                 | Showing: ${startRow}-${endRow}
                 | Page: ${currentPage}/${totalPages}
               </div>


### PR DESCRIPTION
## Description

This PR fixes issue #262 where pagination controls did not dynamically adapt to search filters, letting users navigate to extra empty pages, and currentPage did not reset to 1 upon search query changes.

### Linked Issue

Fixes #262

### Changes Made

- **`search.js`**: Reset `currentPage = 1` on input, clear button click, and escape keypress.
- **`leaderboard.html`**: Saved dynamic filtered page count to `window.totalPages` inside `applyFiltersAndRender()`.
- **`pagination.js`**: Updated the "Next" page click listener to use `window.totalPages` instead of recalculating from the raw global dataset length.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

*Note: Verified by starting the server locally, navigating to page 3, searching for "Nikhil" (which only has 1 match), confirming the pagination stats correctly updated to `Page: 1/1`, and verifying the "Next" button was disabled. Clearing search successfully restored normal multi-page pagination.*

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue
