### PR TITLE
feat(devops): exempt 'status:blocked' issues and PRs from stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,5 +18,7 @@ jobs:
           stale-pr-message: "This PR has been inactive for 14 days and has been marked as stale. If you are still working on it, please leave a comment."
           stale-issue-label: "stale"
           stale-pr-label: "stale"
+          exempt-issue-labels: "status:blocked"
+          exempt-pr-labels: "status:blocked"
           days-before-stale: 14
           days-before-close: 5


### PR DESCRIPTION
### Description
This PR resolves #276 by updating the stale workflow configuration to exempt issues and pull requests labeled with `status:blocked`. 

### Proposed Changes
- Added `exempt-issue-labels: "status:blocked"` to the stale GitHub Actions workflow.
- Added `exempt-pr-labels: "status:blocked"` to the stale GitHub Actions workflow.

### Related Issues
Closes #276
