### PR TITLE
fix: prevent rank change tooltip from overlapping sticky leaderboard header

### DIFF
--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -2861,7 +2861,8 @@ body::-webkit-scrollbar-thumb {
 .rank-change[data-tooltip]::before {
   content: attr(data-tooltip);
   position: absolute;
-  bottom: 140%;
+  bottom: 140%;      /* Default position */
+  top: auto;
   left: 50%;
   transform: translateX(-50%);
   background: var(--bg-raised);
@@ -2878,6 +2879,11 @@ body::-webkit-scrollbar-thumb {
   pointer-events: none;
   transition: opacity 0.15s ease-in-out;
   box-shadow: 0 0 15px rgba(0, 255, 65, 0.2);
+}
+/* Prevent tooltip from overlapping the sticky header */
+.leaderboard-row:nth-child(-n + 3) .rank-change[data-tooltip]::before {
+  top: 140%;
+  bottom: auto;
 }
 
 .rank-change[data-tooltip]:hover::before {

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -2297,6 +2297,14 @@ body::-webkit-scrollbar-thumb {
   }
 }
 
+.tooltip-score:hover {
+  z-index: 100;
+}
+
+.tooltip-score.active {
+  z-index: 100;
+}
+
 .tooltip-score.active .score-tooltip {
   opacity: 1;
   visibility: visible;
@@ -2861,8 +2869,7 @@ body::-webkit-scrollbar-thumb {
 .rank-change[data-tooltip]::before {
   content: attr(data-tooltip);
   position: absolute;
-  bottom: 140%;      /* Default position */
-  top: auto;
+  bottom: 140%;
   left: 50%;
   transform: translateX(-50%);
   background: var(--bg-raised);
@@ -2880,10 +2887,9 @@ body::-webkit-scrollbar-thumb {
   transition: opacity 0.15s ease-in-out;
   box-shadow: 0 0 15px rgba(0, 255, 65, 0.2);
 }
-/* Prevent tooltip from overlapping the sticky header */
-.leaderboard-row:nth-child(-n + 3) .rank-change[data-tooltip]::before {
-  top: 140%;
-  bottom: auto;
+
+.rank-change[data-tooltip]:hover {
+  z-index: 100;
 }
 
 .rank-change[data-tooltip]:hover::before {


### PR DESCRIPTION
## Description

This PR fixes the rank change tooltip being partially hidden behind the sticky leaderboard header on narrower screen widths.

The tooltip position is adjusted for the affected top leaderboard rows, ensuring it remains fully visible while preserving the existing behavior for the remaining rows.

### Linked Issue

Fixes #266

### Changes Made

- Prevented rank change tooltips from overlapping the sticky leaderboard header.
- Adjusted tooltip positioning for the affected leaderboard rows.
- Preserved the existing tooltip behavior for the rest of the leaderboard.

## Type of Change

<!-- Put an 'x' inside the brackets that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

<!-- Describe how you tested your changes -->

- [x] Tested locally
- [x] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

<!-- Required for UI/Visual changes whenever possible -->
<img width="1364" height="767" alt="image" src="https://github.com/user-attachments/assets/6c38c3e6-0fa3-43e5-8be9-206ad7b9c7d3" />

<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/d8bbce0c-1d15-4e31-af2d-e9bc2258cf3a" />

