### PR TITLE
fix: load assets with absolute paths to fix trailing slash subroutes (#284)

### DIFF
--- a/frontend/about.html
+++ b/frontend/about.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -10,9 +10,9 @@
       href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="styles/main.css" />
-    <link rel="icon" type="image/png" href="assets/logo.png" />
-    <script src="js/navbar.js"></script>
+    <link rel="stylesheet" href="/styles/main.css" />
+    <link rel="icon" type="image/png" href="/assets/logo.png" />
+    <script src="/js/navbar.js"></script>
 
     <meta
       name="description"
@@ -324,8 +324,8 @@
         </div>
       </div>
     </main>
-    <script src="js/footer.js"></script>
-    <script src="js/matrix.js"></script>
-    <script src="js/terminal_ui.js"></script>
+    <script src="/js/footer.js"></script>
+    <script src="/js/matrix.js"></script>
+    <script src="/js/terminal_ui.js"></script>
   </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,8 +10,8 @@
       href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="styles/main.css" />
-    <link rel="icon" type="image/png" href="assets/logo.png" />
+    <link rel="stylesheet" href="/styles/main.css" />
+    <link rel="icon" type="image/png" href="/assets/logo.png" />
     <meta
       name="description"
       content="An open leaderboard for PVG students grinding LeetCode. Track your daily, weekly, monthly and overall progress — ranked by difficulty-weighted score."
@@ -92,8 +92,8 @@
         </div>
       </div>
     </main>
-    <script src="js/boot.js"></script>
-    <script src="js/hero_fx.js"></script>
-    <script src="js/matrix.js"></script>
+    <script src="/js/boot.js"></script>
+    <script src="/js/hero_fx.js"></script>
+    <script src="/js/matrix.js"></script>
   </body>
 </html>

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -10,18 +10,18 @@
       href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="styles/main.css" />
-    <link rel="icon" type="image/png" href="assets/logo.png" />
-    <script src="js/navbar.js"></script>
-    <script src="js/leaderboard/tooltip.js"></script>
-    <script src="js/leaderboard/render.js"></script>
-    <script src="js/leaderboard/pagination.js"></script>
-    <script src="js/leaderboard/search.js"></script>
+    <link rel="stylesheet" href="/styles/main.css" />
+    <link rel="icon" type="image/png" href="/assets/logo.png" />
+    <script src="/js/navbar.js"></script>
+    <script src="/js/leaderboard/tooltip.js"></script>
+    <script src="/js/leaderboard/render.js"></script>
+    <script src="/js/leaderboard/pagination.js"></script>
+    <script src="/js/leaderboard/search.js"></script>
     <script
       src="https://cdn.jsdelivr.net/npm/chart.js"
       nonce="__NONCE__"
     ></script>
-    <script src="js/leaderboard/compare.js" nonce="__NONCE__"></script>
+    <script src="/js/leaderboard/compare.js" nonce="__NONCE__"></script>
 
     <meta
       name="description"
@@ -200,7 +200,7 @@
                   Easy = 1 point<br />
                   Medium = 3 points<br />
                   Hard = 5 points<br />
-                  <a href="about.html">More details</a>
+                  <a href="/about">More details</a>
                 </div>
               </div>
             </div>
@@ -842,10 +842,10 @@
     <!-- Scroll to Top button -->
     <button id="scroll-top-btn" aria-label="Scroll to top">⮝</button>
 
-    <script src="js/leaderboard/mobile-scroll-top.js"></script>
-    <script src="js/leaderboard/sync-changes.js"></script>
-    <script src="js/footer.js"></script>
-    <script src="js/matrix.js"></script>
-    <script src="js/terminal_ui.js"></script>
+    <script src="/js/leaderboard/mobile-scroll-top.js"></script>
+    <script src="/js/leaderboard/sync-changes.js"></script>
+    <script src="/js/footer.js"></script>
+    <script src="/js/matrix.js"></script>
+    <script src="/js/terminal_ui.js"></script>
   </body>
 </html>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -13,8 +13,8 @@
       rel="stylesheet"
     />
 
-    <link rel="stylesheet" href="styles/main.css" />
-    <link rel="icon" type="image/png" href="assets/logo.png" />
+    <link rel="stylesheet" href="/styles/main.css" />
+    <link rel="icon" type="image/png" href="/assets/logo.png" />
 
     <style>
       .legal-content h2 {
@@ -302,6 +302,6 @@
       </div>
     </main>
 
-    <script src="js/matrix.js"></script>
+    <script src="/js/matrix.js"></script>
   </body>
 </html>

--- a/frontend/registration.html
+++ b/frontend/registration.html
@@ -10,9 +10,9 @@
       href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="styles/main.css" />
-    <link rel="icon" type="image/png" href="assets/logo.png" />
-    <script src="js/navbar.js"></script>
+    <link rel="stylesheet" href="/styles/main.css" />
+    <link rel="icon" type="image/png" href="/assets/logo.png" />
+    <script src="/js/navbar.js"></script>
 
     <meta
       name="description"
@@ -592,8 +592,8 @@
           .addEventListener("click", dismissError);
       });
     </script>
-    <script src="js/footer.js"></script>
-    <script src="js/matrix.js"></script>
-    <script src="js/terminal_ui.js"></script>
+    <script src="/js/footer.js"></script>
+    <script src="/js/matrix.js"></script>
+    <script src="/js/terminal_ui.js"></script>
   </body>
 </html>

--- a/frontend/terms.html
+++ b/frontend/terms.html
@@ -13,8 +13,8 @@
       rel="stylesheet"
     />
 
-    <link rel="stylesheet" href="styles/main.css" />
-    <link rel="icon" type="image/png" href="assets/logo.png" />
+    <link rel="stylesheet" href="/styles/main.css" />
+    <link rel="icon" type="image/png" href="/assets/logo.png" />
 
     <style>
       .legal-content h2 {
@@ -299,6 +299,6 @@
       </div>
     </main>
 
-    <script src="js/matrix.js"></script>
+    <script src="/js/matrix.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Description

This PR resolves an asset loading issue where CSS stylesheets, favicons, tooltips, and JavaScript files fail to resolve correctly when routes are accessed with a trailing slash (e.g. `https://codepvg.onrender.com/leaderboard/`). This behavior occurred because assets were linked using relative paths, causing the browser to look for files relative to the subpath (e.g., `/leaderboard/styles/main.css`) rather than the root directory.

### Linked Issue

Fixes #284

### Changes Made

Modified the following HTML pages to use absolute paths (starting with `/`) for their styles, icon/favicon, scripts, and internal relative links:
- `frontend/index.html`
- `frontend/about.html`
- `frontend/leaderboard.html` (including changing relative `about.html` link inside tooltip to `/about`)
- `frontend/privacy.html`
- `frontend/registration.html`
- `frontend/terms.html`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

<!-- Required for UI/Visual changes whenever possible -->
