### PR TITLE
fix: change aggressive username validation event to blur (#286)

### DIFF
--- a/frontend/registration.html
+++ b/frontend/registration.html
@@ -372,30 +372,20 @@
           leetcodeInput.value = username;
         });
 
-        leetcodeInput.addEventListener("input", (e) => {
-          const cursorPosition = e.target.selectionStart;
-          const originalLength = e.target.value.length;
-
+        leetcodeInput.addEventListener("blur", (e) => {
           e.target.value = extractUsername(e.target.value);
-
-          const newLength = e.target.value.length;
-          const diff = originalLength - newLength;
-          e.target.setSelectionRange(
-            cursorPosition - diff,
-            cursorPosition - diff,
-          );
         });
 
         form.addEventListener("submit", async (e) => {
           e.preventDefault();
+          const leetcodeInput = document.getElementById("leetcodeId");
+          leetcodeInput.value = extractUsername(leetcodeInput.value);
+
           const nameVal = document.getElementById("name").value.trim();
-          const leetcodeVal = document
-            .getElementById("leetcodeId")
-            .value.trim();
+          const leetcodeVal = leetcodeInput.value.trim();
 
           // First, clear any previous error states
           const nameInput = document.getElementById("name");
-          const leetcodeInput = document.getElementById("leetcodeId");
 
           const nameTarget =
             nameInput.closest(".form-input-bash-wrapper") || nameInput;


### PR DESCRIPTION
## Description

This PR fixes the aggressive input validation on the LeetCode Username input field in `registration.html`. Previously, formatting occurred on every single keystroke (`input` event), which blocked users from manually typing special characters (like `.` or `/`) that are necessary when typing a profile URL.

### Linked Issue

Fixes #286

### Changes Made

- Replaced the `input` event listener on the username input field with a `blur` event listener to run `extractUsername` only when the input loses focus.
- Kept the `paste` event listener as-is so users who copy-paste still get instant extraction.
- Added a validation formatting call (`extractUsername`) at the start of the `submit` event listener to guarantee any typed inputs are formatted before checking or sending the request.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

<!-- Required for UI/Visual changes whenever possible -->
