### PR TITLE
fix: replace process.exit(1) with throw err in processTimeframe helper(#279)

### DIFF
--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -317,8 +317,11 @@ async function processTimeframe(
     previousData = JSON.parse(rawData);
     console.log(`Previous ${periodName}'s data loaded successfully`);
   } catch (err) {
-    console.error(`Failed to load previous file: `, err.message);
-    process.exit(1);
+    console.error(
+      `Failed to load previous file for ${periodName}: `,
+      err.message,
+    );
+    throw err;
   }
 
   console.log(" ");
@@ -370,10 +373,9 @@ async function processTimeframe(
     console.log(`${periodName} data saved successfully`);
     return data;
   } catch (err) {
-    console.error(`Failed to write json file: `, err.message);
-    process.exit(1);
+    console.error(`Failed to write ${periodName}.json: `, err.message);
+    throw err;
   }
-  return data;
 }
 
 (async () => {
@@ -533,27 +535,33 @@ async function processTimeframe(
   }
 
   // Process timeframe-based leaderboards using the shared function
-  const dailyData = await processTimeframe(
-    overallData,
-    DATA_DIR,
-    "daily",
-    1,
-    badgesMap,
-  );
-  const weeklyData = await processTimeframe(
-    overallData,
-    DATA_DIR,
-    "weekly",
-    7,
-    badgesMap,
-  );
-  const monthlyData = await processTimeframe(
-    overallData,
-    DATA_DIR,
-    "monthly",
-    30,
-    badgesMap,
-  );
+  let dailyData, weeklyData, monthlyData;
+  try {
+    dailyData = await processTimeframe(
+      overallData,
+      DATA_DIR,
+      "daily",
+      1,
+      badgesMap,
+    );
+    weeklyData = await processTimeframe(
+      overallData,
+      DATA_DIR,
+      "weekly",
+      7,
+      badgesMap,
+    );
+    monthlyData = await processTimeframe(
+      overallData,
+      DATA_DIR,
+      "monthly",
+      30,
+      badgesMap,
+    );
+  } catch (err) {
+    console.error(`[FATAL] Timeframe processing aborted: ${err.message}`);
+    process.exit(1);
+  }
 
   const overallMap = new Map(
     overallData.map((u) => [


### PR DESCRIPTION
## Description

This PR fixes Issue #279 by replacing `process.exit(1)` with `throw err` inside the `processTimeframe()` helper function in `scripts/sync-leaderboard.js`. Previously, `process.exit(1)` killed the entire Node.js process immediately from within a reusable helper function, bypassing cleanup (e.g., atomic write tmp file cleanup) and leaving data in an inconsistent state if partial writes occurred.

### Linked Issue

Fixes #279

### Changes Made

- **Line 321** — Replaced `process.exit(1)` with `throw err` inside the catch block for failing to load the previous timeframe file. Error message now includes the `periodName` (daily/weekly/monthly) for easier debugging.
- **Line 374** — Replaced `process.exit(1)` with `throw err` inside the catch block for failing to write the timeframe JSON file. Error message now includes the `periodName`.
- **Line 376** — Removed the unreachable `return data;` statement that could never execute because `process.exit(1)` terminated the process before it.
- **Lines 536–568** — Wrapped the three `processTimeframe()` calls at the top-level IIFE in a try/catch that logs a `[FATAL]` message and calls `process.exit(1)` once — consolidating error handling to a single exit point.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally (syntax validation with `node --check`)
- [x] No console errors introduced
- [x] `npx prettier --write` passes cleanly

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue