### PR TITLE
feat: add retry logic and reduce concurrency in analyze-inactivity (#280

### DIFF
--- a/scripts/analyze-inactivity.js
+++ b/scripts/analyze-inactivity.js
@@ -4,6 +4,9 @@ const axios = require("axios");
 const fs = require("fs");
 const path = require("path");
 
+const { setupRetryInterceptor } = require("./lib/retry-interceptor");
+setupRetryInterceptor();
+
 const THRESHOLD_DAYS = 90;
 const MS_IN_A_DAY = 1000 * 60 * 60 * 24;
 
@@ -48,12 +51,13 @@ async function fetchData(url) {
 
   const baseUrl = "https://leetcode-api-dun.vercel.app/";
   const inactiveUsers = [];
+  const unreachableUsers = [];
   const now = new Date();
 
   console.log(" ");
   console.log("Starting daily full sync inactivity analysis...");
 
-  const CONCURRENCY_LIMIT = 50;
+  const CONCURRENCY_LIMIT = 20;
 
   for (let i = 0; i < users.length; i += CONCURRENCY_LIMIT) {
     const batch = users.slice(i, i + CONCURRENCY_LIMIT);
@@ -64,7 +68,8 @@ async function fetchData(url) {
 
         const profile = await fetchData(baseUrl + username);
         if (!profile) {
-          console.log(`${username}: skipped (API error)`);
+          console.log(`${username}: unreachable (API error after retries)`);
+          unreachableUsers.push(username);
           return;
         }
 
@@ -100,6 +105,7 @@ async function fetchData(url) {
     generatedAt: now.toISOString(),
     thresholdDays: THRESHOLD_DAYS,
     inactiveUsers: inactiveUsers.sort(),
+    unreachableUsers: unreachableUsers.sort(),
   };
 
   console.log("Writing inactivity analysis data to inactive-users.json...");

--- a/scripts/lib/retry-interceptor.js
+++ b/scripts/lib/retry-interceptor.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const axios = require("axios");
+
+/** Maximum number of retry attempts for a failed request. */
+const MAX_RETRIES = 3;
+
+/** Base delay (ms) before the first retry; doubles with each attempt. */
+const INITIAL_DELAY_MS = 1000;
+
+/** Global flag to ensure the interceptor is only registered once per process. */
+let interceptorRegistered = false;
+
+/**
+ * Registers an axios response interceptor that automatically retries failed
+ * requests caused by rate-limiting (429), server errors (5xx), or network
+ * failures (timeout / connection errors).
+ *
+ * Retries use exponential backoff with jitter up to {@link MAX_RETRIES} times.
+ *
+ * Safe to call multiple times — the interceptor is only attached on the first
+ * invocation.
+ */
+function setupRetryInterceptor() {
+  if (interceptorRegistered) {
+    return;
+  }
+
+  axios.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      const { config } = error;
+
+      if (!config) {
+        return Promise.reject(error);
+      }
+
+      config.__retryCount = config.__retryCount || 0;
+
+      const isRateLimited = error.response && error.response.status === 429;
+      const isServerError =
+        error.response &&
+        error.response.status >= 500 &&
+        error.response.status <= 599;
+      const isNetworkError =
+        !error.response ||
+        error.code === "ECONNABORTED" ||
+        error.message.includes("timeout");
+
+      const shouldRetry =
+        (isRateLimited || isServerError || isNetworkError) &&
+        config.__retryCount < MAX_RETRIES;
+
+      if (shouldRetry) {
+        config.__retryCount += 1;
+
+        // Exponential backoff with jitter
+        const backoffDelay =
+          INITIAL_DELAY_MS * Math.pow(2, config.__retryCount - 1);
+        const jitter = Math.random() * 200;
+        const delay = backoffDelay + jitter;
+
+        console.warn(
+          `[Retry ${config.__retryCount}/${MAX_RETRIES}] Request failed for ${config.url} (${error.message}). Retrying in ${Math.round(delay)}ms...`,
+        );
+
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        return axios(config);
+      }
+
+      return Promise.reject(error);
+    },
+  );
+
+  interceptorRegistered = true;
+}
+
+module.exports = { setupRetryInterceptor, MAX_RETRIES, INITIAL_DELAY_MS };

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -4,55 +4,8 @@ const axios = require("axios");
 const fs = require("fs");
 const path = require("path");
 
-// Configure retry settings on axios response
-const MAX_RETRIES = 3;
-const INITIAL_DELAY_MS = 1000;
-
-axios.interceptors.response.use(
-  (response) => response,
-  async (error) => {
-    const { config } = error;
-
-    if (!config) {
-      return Promise.reject(error);
-    }
-
-    config.__retryCount = config.__retryCount || 0;
-
-    const isRateLimited = error.response && error.response.status === 429;
-    const isServerError =
-      error.response &&
-      error.response.status >= 500 &&
-      error.response.status <= 599;
-    const isNetworkError =
-      !error.response ||
-      error.code === "ECONNABORTED" ||
-      error.message.includes("timeout");
-
-    const shouldRetry =
-      (isRateLimited || isServerError || isNetworkError) &&
-      config.__retryCount < MAX_RETRIES;
-
-    if (shouldRetry) {
-      config.__retryCount += 1;
-
-      // Exponential backoff with jitter
-      const backoffDelay =
-        INITIAL_DELAY_MS * Math.pow(2, config.__retryCount - 1);
-      const jitter = Math.random() * 200;
-      const delay = backoffDelay + jitter;
-
-      console.warn(
-        `[Retry ${config.__retryCount}/${MAX_RETRIES}] Request failed for ${config.url} (${error.message}). Retrying in ${Math.round(delay)}ms...`,
-      );
-
-      await new Promise((resolve) => setTimeout(resolve, delay));
-      return axios(config);
-    }
-
-    return Promise.reject(error);
-  },
-);
+const { setupRetryInterceptor } = require("./lib/retry-interceptor");
+setupRetryInterceptor();
 
 function atomicWrite(filePath, data) {
   const dir = path.dirname(filePath);


### PR DESCRIPTION
## Description

This PR brings `analyze-inactivity.js` up to parity with `sync-leaderboard.js` by adding three resiliency safeguards that were missing: retry logic for API failures, reduced concurrency to avoid rate-limiting, and fallback tracking for unreachable users.

The axios retry interceptor (exponential backoff with jitter, up to 3 retries on 429/5xx/network errors) has been extracted from `sync-leaderboard.js` into a shared module at `scripts/lib/retry-interceptor.js` so both scripts use the same retry configuration.

### Linked Issue

Fixes #280

### Changes Made

- **Created `scripts/lib/retry-interceptor.js`** — New shared module exporting `setupRetryInterceptor()`, `MAX_RETRIES` (3), and `INITIAL_DELAY_MS` (1000). Includes a guard to prevent double-registration if called from multiple scripts in the same process.
- **Updated `scripts/sync-leaderboard.js`** — Replaced 53 lines of inline retry interceptor with a 2-line `require("./lib/retry-interceptor")` call. Zero behavioral change.
- **Updated `scripts/analyze-inactivity.js`:**
  - Added `require("./lib/retry-interceptor")` — API calls now auto-retry up to 3× with exponential backoff + jitter.
  - Reduced `CONCURRENCY_LIMIT` from 50 to 20 (matches `sync-leaderboard.js` throughput).
  - Failed users (after all retries) are tracked in a new `unreachableUsers` array in the output JSON instead of being silently dropped.
  - Log message changed from `"skipped (API error)"` to `"unreachable (API error after retries)"` for clarity.

### What stayed unchanged

- `inactiveUsers` output format (still `string[]`) — fully backward-compatible.
- `sync-leaderboard.js` behavior — identical retry logic, just imported from shared module.
- No changes to `fetch-user-info.js`, `server.js`, `frontend/`, `.github/workflows/`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally (syntax validation with `node --check` on all 3 changed files + `server.js`)
- [x] No console errors introduced
- [x] `npx prettier --write` passes cleanly

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue