### PR TITLE
[SECURITY] Add principle-of-least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/analyze-inactivity.yml
+++ b/.github/workflows/analyze-inactivity.yml
@@ -6,6 +6,9 @@ on:
     - cron: "45 5,11,17,23 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     if: github.repository == 'codepvg/leetcode-ranking'

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -4,6 +4,11 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
 jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds explicit permissions blocks to GitHub Actions workflows that were relying on repository-wide defaults, implementing least-privilege access to prevent supply-chain attacks through compromised third-party actions.

## Problem

Workflows without explicit permissions blocks inherit overly broad write access to all repository resources. A compromised third-party action in the workflow can push arbitrary commits, modify issues, exfiltrate secrets, or alter leaderboard data.

## Solution

Added minimal permissions declarations based on actual workflow requirements:

**analyze-inactivity.yml:**
- Added: permissions: { contents: read }
- Only needs to checkout code; no write operations

**slash-command-dispatch.yml:**
- Added: permissions: { contents: read, issues: read, pull-requests: read }
- Uses custom PAT token for actions; job needs only read access

**Verified Already Configured:**
- sync-leaderboard.yml: contents: write, issues: write
- contributor-reminder.yml: issues: write, pull-requests: write  
- format-command.yml: contents: write, pull-requests: write, issues: write
- stale.yml: issues: write, pull-requests: write
- prettier-check.yml: contents: write

## Security Impact

✅ Reduces GITHUB_TOKEN attack surface via principle-of-least-privilege
✅ Prevents write access to tokens that don't need it
✅ Limits blast radius of compromised action dependencies

## Related

Closes #304