### PR TITLE
feat: fetch and dynamically render local leaderboard ranks in profile page

### DIFF
--- a/frontend/js/user/ranks.js
+++ b/frontend/js/user/ranks.js
@@ -47,8 +47,9 @@ async function loadLeaderboardRanks(username) {
 // Automatically fire on load
 document.addEventListener("DOMContentLoaded", () => {
   const pathSegments = window.location.pathname.split("/");
-  const username = pathSegments[pathSegments.length - 1];
-
+  const username =
+    pathSegments[pathSegments.length - 1] ||
+    pathSegments[pathSegments.length - 2];
   if (username) {
     loadLeaderboardRanks(username);
   }

--- a/frontend/js/user/ranks.js
+++ b/frontend/js/user/ranks.js
@@ -1,0 +1,55 @@
+async function loadLeaderboardRanks(username) {
+  const periods = ["overall", "monthly", "weekly", "daily"];
+
+  try {
+    const res = await fetch(`/api/user/${username}`);
+    if (!res.ok) throw new Error("API response error");
+
+    const data = await res.json();
+    const ranks = data.leaderboardRanks;
+    if (!ranks) return;
+
+    periods.forEach((period) => {
+      const rankEl = document.getElementById(`${period}-rank`);
+      const itemContainer = document.getElementById(`${period}-item`);
+
+      const rankData = ranks[period];
+
+      // Clean fallback if rank is not present, is '--', or has a 0 rank score
+      if (
+        !rankData ||
+        rankData.rank === "--" ||
+        rankData.rank === 0 ||
+        rankData.rank === null
+      ) {
+        if (rankEl) rankEl.textContent = "--";
+        if (itemContainer) itemContainer.classList.add("placeholder-rank");
+        return;
+      }
+
+      if (itemContainer) {
+        itemContainer.classList.remove("placeholder-rank");
+      }
+
+      if (rankEl) {
+        rankEl.textContent = Number(rankData.rank);
+      }
+    });
+  } catch (err) {
+    console.error("Error loading leaderboard ranks:", err);
+    periods.forEach((period) => {
+      const el = document.getElementById(`${period}-rank`);
+      if (el) el.textContent = "--";
+    });
+  }
+}
+
+// Automatically fire on load
+document.addEventListener("DOMContentLoaded", () => {
+  const pathSegments = window.location.pathname.split("/");
+  const username = pathSegments[pathSegments.length - 1];
+
+  if (username) {
+    loadLeaderboardRanks(username);
+  }
+});

--- a/frontend/user.html
+++ b/frontend/user.html
@@ -529,21 +529,21 @@
                 >--</span
               >
             </div>
-            <div class="rank-item placeholder-rank">
+            <div class="rank-item" id="overall-item">
               <span class="rank-label">OVERALL:</span>
-              <span class="rank-value">--</span>
+              <span id="overall-rank" class="rank-value">--</span>
             </div>
-            <div class="rank-item placeholder-rank">
+            <div class="rank-item" id="monthly-item">
               <span class="rank-label">MONTHLY:</span>
-              <span class="rank-value">--</span>
+              <span id="monthly-rank" class="rank-value">--</span>
             </div>
-            <div class="rank-item placeholder-rank">
+            <div class="rank-item" id="weekly-item">
               <span class="rank-label">WEEKLY:</span>
-              <span class="rank-value">--</span>
+              <span id="weekly-rank" class="rank-value">--</span>
             </div>
-            <div class="rank-item placeholder-rank">
+            <div class="rank-item" id="daily-item">
               <span class="rank-label">DAILY:</span>
-              <span class="rank-value">--</span>
+              <span id="daily-rank" class="rank-value">--</span>
             </div>
           </div>
         </div>
@@ -634,6 +634,7 @@
     <script nonce="__NONCE__" src="/js/user/historical-graphs.js"></script>
     <script src="/js/user/badges.js"></script>
     <script src="/js/user/contest.js"></script>
+    <script src="/js/user/ranks.js"></script>
     <script src="/js/footer.js"></script>
     <script src="/js/matrix.js"></script>
     <script src="/js/terminal_ui.js"></script>


### PR DESCRIPTION
## Description

This PR connects the frontend user profile banner to the newly exposed leaderboard rankings API data. It reads the local rankings (Overall, Monthly, Weekly, and Daily) and updates the dashboard UI dynamically on page load using a standalone, self-contained architecture consistent with other widgets like badges and contests.

Related to #195 

### Changes Made

- **HTML Update:** Added unique target IDs (`overall-item`, `overall-rank`, etc.) to the rankings layout structure inside `user.html`.
- **New Feature Script:** Created `/js/user/ranks.js` to extract the username from the URL path, query the user profile API endpoint, and populate the banner.
- **Robust Rendering:** Formatted the values cleanly as raw numbers and implemented dynamic fallback checking (hiding items/showing `--` if the rank is `0` or missing).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [ ] I have formatted my code locally by running `npx prettier --write .` before submitting
- [ ] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

<!-- Required for UI/Visual changes whenever possible -->