### PR TITLE
fix: watch HTML/CSS files in dev script (#281)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon --ext js,html,css server.js"
   },
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -81,16 +81,8 @@ app.use((req, res, next) => {
 // 4. HTML page routes — inject per-request nonce into __NONCE__ placeholders
 const htmlCache = {};
 function serveHtml(res, filePath) {
-  let stats;
-  try {
-    stats = fs.statSync(filePath);
-  } catch (err) {
-    return res.status(500).send("Error loading page");
-  }
-
-  const cached = htmlCache[filePath];
-  if (cached && cached.mtime >= stats.mtimeMs) {
-    const html = cached.data.replace(/__NONCE__/g, res.locals.nonce);
+  if (htmlCache[filePath]) {
+    const html = htmlCache[filePath].replace(/__NONCE__/g, res.locals.nonce);
     return res.type("html").send(html);
   }
 
@@ -98,7 +90,7 @@ function serveHtml(res, filePath) {
     if (err) {
       return res.status(500).send("Error loading page");
     }
-    htmlCache[filePath] = { mtime: stats.mtimeMs, data };
+    htmlCache[filePath] = data;
     const html = data.replace(/__NONCE__/g, res.locals.nonce);
     res.type("html").send(html);
   });

--- a/server.js
+++ b/server.js
@@ -81,8 +81,16 @@ app.use((req, res, next) => {
 // 4. HTML page routes — inject per-request nonce into __NONCE__ placeholders
 const htmlCache = {};
 function serveHtml(res, filePath) {
-  if (htmlCache[filePath]) {
-    const html = htmlCache[filePath].replace(/__NONCE__/g, res.locals.nonce);
+  let stats;
+  try {
+    stats = fs.statSync(filePath);
+  } catch (err) {
+    return res.status(500).send("Error loading page");
+  }
+
+  const cached = htmlCache[filePath];
+  if (cached && cached.mtime >= stats.mtimeMs) {
+    const html = cached.data.replace(/__NONCE__/g, res.locals.nonce);
     return res.type("html").send(html);
   }
 
@@ -90,7 +98,7 @@ function serveHtml(res, filePath) {
     if (err) {
       return res.status(500).send("Error loading page");
     }
-    htmlCache[filePath] = data;
+    htmlCache[filePath] = { mtime: stats.mtimeMs, data };
     const html = data.replace(/__NONCE__/g, res.locals.nonce);
     res.type("html").send(html);
   });


### PR DESCRIPTION
## Description

This PR updates the dev script in package.json to make nodemon watch .html and .css files in addition to .js. Previously, edits to frontend files (e.g., leaderboard.html, user.html) during development required a manual server restart to take effect because the in-memory HTML cache in serveHtml() was never invalidated.

Rather than adding runtime cache invalidation (which adds filesystem overhead to every request), nodemon now watches .html and .css files so the server auto-restarts when frontend files change ? refreshing the cache naturally.

### Linked Issue

Fixes #281

### Changes Made

- Updated package.json dev script ? "dev": "nodemon server.js" ? "dev": "nodemon --ext js,html,css server.js"
- Reverted server.js ? no runtime cache changes. The serveHtml() function keeps the original indefinite cache; the dev cycle is solved at the tooling level instead.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally (validated nodemon flag syntax)
- [x] No console errors introduced
- [x] 
px prettier --write passes cleanly

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running 
px prettier --write . before submitting
- [x] I am submitting my PR from a dedicated feature/* branch, not the main branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue
