### PR TITLE
bug: Weekly Target progress resets to totalSolved on transient API failure (#297)

### DIFF
--- a/frontend/js/user/goal-setter.js
+++ b/frontend/js/user/goal-setter.js
@@ -117,31 +117,44 @@
     }
 
     async function fetchSolvedCount(metric) {
-      try {
-        const res = await fetch("/api/user/" + username);
-        if (!res.ok) return 0;
-        const data = await res.json();
-        var history = data.history;
-        if (!Array.isArray(history) || history.length === 0) return 0;
-        var latest = history[history.length - 1];
-        if (metric === "easy") return Number(latest.easy) || 0;
-        if (metric === "medium") return Number(latest.medium) || 0;
-        if (metric === "hard") return Number(latest.hard) || 0;
-        return (
-          (Number(latest.easy) || 0) +
-          (Number(latest.medium) || 0) +
-          (Number(latest.hard) || 0)
-        );
-      } catch {
-        return 0;
+      const res = await fetch("/api/user/" + username);
+      if (!res.ok) {
+        throw new Error("Failed to fetch solved count: " + res.status);
       }
+      const data = await res.json();
+      const history = data.history;
+      if (!Array.isArray(history) || history.length === 0) return 0;
+      const latest = history[history.length - 1];
+      if (metric === "easy") return Number(latest.easy) || 0;
+      if (metric === "medium") return Number(latest.medium) || 0;
+      if (metric === "hard") return Number(latest.hard) || 0;
+      return (
+        (Number(latest.easy) || 0) +
+        (Number(latest.medium) || 0) +
+        (Number(latest.hard) || 0)
+      );
     }
 
     async function render() {
       const goal = loadGoal(username);
       if (goal) {
-        const solved = await fetchSolvedCount(goal.metric);
-        showProgress(goal, solved);
+        try {
+          const solved = await fetchSolvedCount(goal.metric);
+          showProgress(goal, solved);
+        } catch (e) {
+          console.error("Error loading goal progress:", e);
+          elLabel.textContent =
+            "TARGET: " +
+            goal.target +
+            " " +
+            goal.metric.toUpperCase() +
+            " / WEEK";
+          elBar.textContent = "[ FAILED TO SYNC PROGRESS ]";
+          elBar.style.color = "var(--red)";
+          elCount.textContent = "API error, please refresh later";
+          elDisplay.style.display = "block";
+          elSetter.style.display = "none";
+        }
       } else {
         showSetter();
       }
@@ -155,9 +168,22 @@
         return;
       }
       elInput.style.borderColor = "";
-      const goal = saveGoal(username, metric, target);
-      const solved = await fetchSolvedCount(metric);
-      showProgress(goal, solved);
+
+      try {
+        const solved = await fetchSolvedCount(metric);
+        const goal = saveGoal(username, metric, target);
+        showProgress(goal, solved);
+      } catch (e) {
+        console.error("Error setting goal:", e);
+        elInput.style.borderColor = "#ff4c4c";
+        elInput.value = "";
+        elInput.placeholder = "API Error, retry";
+      }
+    });
+
+    elInput.addEventListener("focus", function () {
+      elInput.placeholder = "e.g. 10";
+      elInput.style.borderColor = "";
     });
 
     elReset.addEventListener("click", function () {


### PR DESCRIPTION
## Description

Fixes the issue where a user's weekly target baseline count (`goal.baseCount`) would get overwritten or initialized to `0` during a transient API failure (such as rate limits or network issues) on profile page load. This prevented progress from resetting correctly and immediately marked targets as completed.

### Linked Issue

Fixes #297

### Changes Made

- Refactored `fetchSolvedCount()` to propagate fetch failures and network errors instead of defaulting to returning `0`.
- Caught errors in `render()` so that the baseline count is not initialized to `0` when the API fails on load. Instead, the UI displays `[ FAILED TO SYNC PROGRESS ]` in red.
- Wrapped the save button handler in a `try-catch` block to verify the API response before saving the target to localStorage. If it fails, the input border turns red and updates the placeholder to `"API Error, retry"`.
- Added a focus event listener to reset the target input field's error states and restore the default placeholder.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [x] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording