### PR TITLE
Move badge logic to frontend

### DIFF
--- a/frontend/js/user/badges.js
+++ b/frontend/js/user/badges.js
@@ -1,7 +1,7 @@
 const ALL_BADGES = [
   { id: "HOT_STREAK", title: "Solved >= 1 problem every day for 7 days" },
   { id: "SPEEDRUN", title: "Top 3 problem-solving velocity this week" },
-  { id: "UP_LINK", title: "Jumped 5+ positions in overall ranks today" }
+  { id: "UP_LINK", title: "Jumped 5+ positions in overall ranks today" },
 ];
 
 async function loadBadges(username) {
@@ -25,7 +25,8 @@ async function loadBadges(username) {
       let streak = true;
       for (let j = 1; j < recent.length; j++) {
         const todayTotals = recent[j].easy + recent[j].medium + recent[j].hard;
-        const yesterdayTotals = recent[j - 1].easy + recent[j - 1].medium + recent[j - 1].hard;
+        const yesterdayTotals =
+          recent[j - 1].easy + recent[j - 1].medium + recent[j - 1].hard;
         if (todayTotals - yesterdayTotals < 1) {
           streak = false;
           break;
@@ -43,17 +44,21 @@ async function loadBadges(username) {
         const recent = history.slice(-8);
         const first = recent[0];
         const last = recent[recent.length - 1];
-        const weeklyScore = (last.easy - first.easy) + (last.medium - first.medium) * 3 + (last.hard - first.hard) * 5;
+        const weeklyScore =
+          last.easy -
+          first.easy +
+          (last.medium - first.medium) * 3 +
+          (last.hard - first.hard) * 5;
         if (weeklyScore > 0) earnedSet.add("SPEEDRUN");
       }
     }
 
     if (earnedSet.size === 0) return;
 
-    earnedSet.forEach(badgeId => {
+    earnedSet.forEach((badgeId) => {
       const badge = document.createElement("div");
 
-      const badgeDef = ALL_BADGES.find(b => b.id === badgeId);
+      const badgeDef = ALL_BADGES.find((b) => b.id === badgeId);
       const safeClass = badgeId.toLowerCase().replace("_", "");
 
       badge.className = `badge badge-${safeClass}`;
@@ -64,7 +69,6 @@ async function loadBadges(username) {
 
       badgeWall.appendChild(badge);
     });
-
   } catch (err) {
     console.error("Error loading user badges:", err);
   }

--- a/frontend/js/user/badges.js
+++ b/frontend/js/user/badges.js
@@ -1,3 +1,9 @@
+const ALL_BADGES = [
+  { id: "HOT_STREAK", title: "Solved >= 1 problem every day for 7 days" },
+  { id: "SPEEDRUN", title: "Top 3 problem-solving velocity this week" },
+  { id: "UP_LINK", title: "Jumped 5+ positions in overall ranks today" }
+];
+
 async function loadBadges(username) {
   const badgeWall = document.getElementById("badge-wall");
   if (!badgeWall) return;
@@ -9,33 +15,56 @@ async function loadBadges(username) {
     if (!res.ok) throw new Error("API response error");
 
     const data = await res.json();
-    const earnedBadges = data.badges || [];
+    const history = data.history || [];
+    const ranks = data.leaderboardRanks || {};
 
-    if (earnedBadges.length === 0) {
-      return;
+    const earnedSet = new Set();
+
+    if (history.length >= 8) {
+      const recent = history.slice(-8);
+      let streak = true;
+      for (let j = 1; j < recent.length; j++) {
+        const todayTotals = recent[j].easy + recent[j].medium + recent[j].hard;
+        const yesterdayTotals = recent[j - 1].easy + recent[j - 1].medium + recent[j - 1].hard;
+        if (todayTotals - yesterdayTotals < 1) {
+          streak = false;
+          break;
+        }
+      }
+      if (streak) earnedSet.add("HOT_STREAK");
     }
 
-    earnedBadges.forEach((type) => {
+    if (ranks.overall && parseInt(ranks.overall.change, 10) >= 5) {
+      earnedSet.add("UP_LINK");
+    }
+
+    if (ranks.weekly && ranks.weekly.rank !== "--" && ranks.weekly.rank <= 3) {
+      if (history.length >= 2) {
+        const recent = history.slice(-8);
+        const first = recent[0];
+        const last = recent[recent.length - 1];
+        const weeklyScore = (last.easy - first.easy) + (last.medium - first.medium) * 3 + (last.hard - first.hard) * 5;
+        if (weeklyScore > 0) earnedSet.add("SPEEDRUN");
+      }
+    }
+
+    if (earnedSet.size === 0) return;
+
+    earnedSet.forEach(badgeId => {
       const badge = document.createElement("div");
 
-      badge.className = `badge badge-${type.toLowerCase().replace("_", "")}`;
-      badge.textContent = `[${type}]`;
+      const badgeDef = ALL_BADGES.find(b => b.id === badgeId);
+      const safeClass = badgeId.toLowerCase().replace("_", "");
 
-      if (type === "HOT_STREAK")
-        badge.setAttribute(
-          "data-title",
-          "Solved >= 1 problem every day for 7 days",
-        );
-      if (type === "SPEEDRUN")
-        badge.setAttribute(
-          "data-title",
-          "Top 3 problem-solving velocity this week",
-        );
-      if (type === "UP_LINK")
-        badge.setAttribute("data-title", "Jumped 5+ positions in ranks");
+      badge.className = `badge badge-${safeClass}`;
+      badge.textContent = `[${badgeId}]`;
+      if (badgeDef) {
+        badge.setAttribute("data-title", badgeDef.title);
+      }
 
       badgeWall.appendChild(badge);
     });
+
   } catch (err) {
     console.error("Error loading user badges:", err);
   }

--- a/frontend/user.html
+++ b/frontend/user.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -189,7 +189,9 @@
         border: 1px solid;
       }
 
-      .badge-streak {
+
+
+      .badge-hotstreak {
         color: #b08add;
         background: rgba(176, 138, 221, 0.1);
         border-color: rgba(176, 138, 221, 0.3);
@@ -473,46 +475,7 @@
               <span style="color: var(--text-dim)">// PRIVILEGES</span>
             </div>
             <div class="badges-container" id="badge-wall">
-              <div
-                class="badge badge-streak"
-                data-title="Solved >= 1 problem every day for 7 days"
-              >
-                [HOT_STREAK]
-              </div>
-              <div
-                class="badge badge-speedrun"
-                data-title="Top 3 problem-solving velocity this week"
-              >
-                [SPEEDRUN]
-              </div>
-              <div
-                class="badge badge-uplink"
-                data-title="Jumped 5+ positions in ranks"
-              >
-                [UP_LINK]
-              </div>
-              <div
-                style="
-                  color: var(--text-dim);
-                  font-size: 0.8rem;
-                  width: 100%;
-                  margin-top: 8px;
-                  font-family: &quot;Space Mono&quot;, monospace;
-                  display: flex;
-                  align-items: center;
-                  gap: 8px;
-                "
-              >
-                <span style="opacity: 0.5">_UNLOCKED</span>
-                <div
-                  style="
-                    flex: 1;
-                    height: 1px;
-                    background: var(--border);
-                    opacity: 0.3;
-                  "
-                ></div>
-              </div>
+              <!-- Dynamically populated by badges.js -->
             </div>
           </div>
         </div>

--- a/frontend/user.html
+++ b/frontend/user.html
@@ -189,8 +189,6 @@
         border: 1px solid;
       }
 
-
-
       .badge-hotstreak {
         color: #b08add;
         background: rgba(176, 138, 221, 0.1);

--- a/scripts/fetch-user-info.js
+++ b/scripts/fetch-user-info.js
@@ -25,7 +25,6 @@ async function fetchUserInfo(username) {
 
   let history = [];
   let ranking = null;
-  let badges = [];
   let contest = null;
 
   const liveApiUrl = `https://leetcode-api-dun.vercel.app/${username}`;
@@ -51,7 +50,6 @@ async function fetchUserInfo(username) {
       } else if (data && typeof data === "object") {
         // Safe object destructuring for the new profile structure
         history = data.history || [];
-        badges = data.badges || [];
         if (data.leaderboardRanks) {
           leaderboardRanks = data.leaderboardRanks;
         }
@@ -91,7 +89,6 @@ async function fetchUserInfo(username) {
     username,
     ranking,
     leaderboardRanks,
-    badges,
     contest,
     history,
   };

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -51,12 +51,11 @@ function getFileName(daysAgo) {
 async function updateUserDataAsync(
   user,
   DATA_DIR,
-  badgesMap = null,
   ranksObj = null,
 ) {
   const userDataDir = path.join(DATA_DIR, "user-data");
   const userDataPath = path.join(userDataDir, `${user.id}.json`);
-  let userData = { leaderboardRanks: {}, history: [], badges: [] };
+  let userData = { leaderboardRanks: {}, history: [] };
   let history = [];
 
   try {
@@ -97,57 +96,10 @@ async function updateUserDataAsync(
   history.sort((a, b) => new Date(a.date) - new Date(b.date));
 
   userData.history = history;
-  if (badgesMap && badgesMap[user.id]) {
-    userData.badges = [...new Set(badgesMap[user.id])];
-  }
   if (ranksObj) {
     userData.leaderboardRanks = ranksObj;
   }
   await atomicWrite(userDataPath, userData);
-}
-
-async function checkHotStreakAsync(userId, DATA_DIR, badgesMap) {
-  const userDataDir = path.join(DATA_DIR, "user-data");
-  const userDataPath = path.join(userDataDir, `${userId}.json`);
-
-  try {
-    const fileHandle = await fsPromises.readFile(userDataPath, "utf8");
-    const rawData = JSON.parse(fileHandle);
-    const history = Array.isArray(rawData) ? rawData : rawData.history || [];
-
-    if (history.length >= 8) {
-      const recentHistory = history.slice(-8);
-      let consecutiveDaysMet = true;
-
-      for (let j = 1; j < recentHistory.length; j++) {
-        const todayTotals =
-          recentHistory[j].easy +
-          recentHistory[j].medium +
-          recentHistory[j].hard;
-        const yesterdayTotals =
-          recentHistory[j - 1].easy +
-          recentHistory[j - 1].medium +
-          recentHistory[j - 1].hard;
-
-        // If they didn't solve at least 1 problem compared to the day before, streak breaks
-        if (todayTotals - yesterdayTotals < 1) {
-          consecutiveDaysMet = false;
-          break;
-        }
-      }
-
-      if (consecutiveDaysMet) {
-        badgesMap[userId].push("HOT_STREAK");
-      }
-    }
-  } catch (err) {
-    if (err.code !== "ENOENT") {
-      console.error(
-        `Failed parsing user data for badge verification on ${userId}:`,
-        err.message,
-      );
-    }
-  }
 }
 
 function assignCompetitionRanks(sortedData) {
@@ -211,7 +163,7 @@ async function getYesterdaySnapshot(filePath) {
   }
 }
 
-async function computeRankChanges(currentSorted, filename, badgesMap = null) {
+async function computeRankChanges(currentSorted, filename) {
   let previousRanks = {};
   const previousData = await getYesterdaySnapshot(filename);
 
@@ -238,12 +190,6 @@ async function computeRankChanges(currentSorted, filename, badgesMap = null) {
         else if (delta < 0) user.rankChange = `${delta}`;
         else user.rankChange = 0;
       }
-
-      if (badgesMap && delta >= 5 && user.score > 0) {
-        if (badgesMap[user.id] && !badgesMap[user.id].includes("UP_LINK")) {
-          badgesMap[user.id].push("UP_LINK");
-        }
-      }
     }
   });
 }
@@ -262,7 +208,6 @@ async function processTimeframe(
   DATA_DIR,
   periodName,
   daysAgo,
-  badgesMap = null,
 ) {
   const data = JSON.parse(JSON.stringify(sourceData));
   console.log(" ");
@@ -303,7 +248,7 @@ async function processTimeframe(
         item.data.mediumSolved = Math.max(
           0,
           item.data.mediumSolved -
-            previousData[previousIndex].data.mediumSolved,
+          previousData[previousIndex].data.mediumSolved,
         );
         item.data.hardSolved = Math.max(
           0,
@@ -316,14 +261,6 @@ async function processTimeframe(
           item.data.hardSolved * 5;
         item.data.totalSolved =
           item.data.easySolved + item.data.mediumSolved + item.data.hardSolved;
-
-        if (
-          periodName === "weekly" &&
-          item.data.totalSolved >= 7 &&
-          badgesMap
-        ) {
-          await checkHotStreakAsync(item.id, DATA_DIR, badgesMap);
-        }
       }),
     );
   }
@@ -336,7 +273,7 @@ async function processTimeframe(
   assignCompetitionRanks(filteredData);
   console.log(`Writing sorted ${periodName} data to ${periodName}.json...`);
   const filepath = path.join(DATA_DIR, `${periodName}.json`);
-  await computeRankChanges(filteredData, `${periodName}.json`, badgesMap);
+  await computeRankChanges(filteredData, `${periodName}.json`);
   try {
     await atomicWrite(filepath, filteredData);
     console.log(`${periodName} data saved successfully`);
@@ -388,10 +325,7 @@ async function processTimeframe(
     process.exit(1);
   }
 
-  const badgesMap = {};
-  users.forEach((user) => {
-    badgesMap[user.id] = [];
-  });
+
 
   const baseUrl = "https://leetcode-api-dun.vercel.app/";
 
@@ -498,7 +432,7 @@ async function processTimeframe(
   assignCompetitionRanks(overallData);
   console.log("Writing sorted daily data to overall file...");
 
-  await computeRankChanges(overallData, "overall.json", badgesMap);
+  await computeRankChanges(overallData, "overall.json");
   try {
     await atomicWrite(overallFilepath, overallData);
     console.log("Daily data saved successfully");
@@ -515,21 +449,18 @@ async function processTimeframe(
       DATA_DIR,
       "daily",
       1,
-      badgesMap,
     );
     weeklyData = await processTimeframe(
       overallData,
       DATA_DIR,
       "weekly",
       7,
-      badgesMap,
     );
     monthlyData = await processTimeframe(
       overallData,
       DATA_DIR,
       "monthly",
       30,
-      badgesMap,
     );
   } catch (err) {
     console.error(`[FATAL] Timeframe processing aborted: ${err.message}`);
@@ -625,13 +556,7 @@ async function processTimeframe(
     console.error("Failed to write changes.json: ", err.message);
   }
 
-  if (Array.isArray(weeklyData)) {
-    weeklyData.slice(0, 3).forEach((user) => {
-      if (badgesMap[user.id] && user.score > 0) {
-        badgesMap[user.id].push("SPEEDRUN");
-      }
-    });
-  }
+
 
   console.log(
     "Updating user data files with history, badges, and pre-calculated ranks...",
@@ -690,7 +615,7 @@ async function processTimeframe(
           };
 
           // Executed asynchronously using fs.promises inside controlled chunk bounds
-          await updateUserDataAsync(user, DATA_DIR, badgesMap, calculatedRanks);
+          await updateUserDataAsync(user, DATA_DIR, calculatedRanks);
         } catch (err) {
           userDataFailures++;
           console.error(

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -48,11 +48,7 @@ function getFileName(daysAgo) {
   return `${year}-${month}-${date}-${day}.json`;
 }
 
-async function updateUserDataAsync(
-  user,
-  DATA_DIR,
-  ranksObj = null,
-) {
+async function updateUserDataAsync(user, DATA_DIR, ranksObj = null) {
   const userDataDir = path.join(DATA_DIR, "user-data");
   const userDataPath = path.join(userDataDir, `${user.id}.json`);
   let userData = { leaderboardRanks: {}, history: [] };
@@ -203,12 +199,7 @@ async function computeRankChanges(currentSorted, filename) {
  * @param {string} periodName - Label for the timeframe ("daily", "weekly", "monthly")
  * @param {number} daysAgo - Number of days to look back for the snapshot file
  */
-async function processTimeframe(
-  sourceData,
-  DATA_DIR,
-  periodName,
-  daysAgo,
-) {
+async function processTimeframe(sourceData, DATA_DIR, periodName, daysAgo) {
   const data = JSON.parse(JSON.stringify(sourceData));
   console.log(" ");
   console.log(`Loading previous ${periodName}'s file...`);
@@ -248,7 +239,7 @@ async function processTimeframe(
         item.data.mediumSolved = Math.max(
           0,
           item.data.mediumSolved -
-          previousData[previousIndex].data.mediumSolved,
+            previousData[previousIndex].data.mediumSolved,
         );
         item.data.hardSolved = Math.max(
           0,
@@ -324,8 +315,6 @@ async function processTimeframe(
     console.error("Failed to load users.json: ", err.message);
     process.exit(1);
   }
-
-
 
   const baseUrl = "https://leetcode-api-dun.vercel.app/";
 
@@ -444,24 +433,9 @@ async function processTimeframe(
   // Process timeframe-based leaderboards using the shared function
   let dailyData, weeklyData, monthlyData;
   try {
-    dailyData = await processTimeframe(
-      overallData,
-      DATA_DIR,
-      "daily",
-      1,
-    );
-    weeklyData = await processTimeframe(
-      overallData,
-      DATA_DIR,
-      "weekly",
-      7,
-    );
-    monthlyData = await processTimeframe(
-      overallData,
-      DATA_DIR,
-      "monthly",
-      30,
-    );
+    dailyData = await processTimeframe(overallData, DATA_DIR, "daily", 1);
+    weeklyData = await processTimeframe(overallData, DATA_DIR, "weekly", 7);
+    monthlyData = await processTimeframe(overallData, DATA_DIR, "monthly", 30);
   } catch (err) {
     console.error(`[FATAL] Timeframe processing aborted: ${err.message}`);
     process.exit(1);
@@ -555,8 +529,6 @@ async function processTimeframe(
   } catch (err) {
     console.error("Failed to write changes.json: ", err.message);
   }
-
-
 
   console.log(
     "Updating user data files with history, badges, and pre-calculated ranks...",


### PR DESCRIPTION
Since more data is now available on the page, it's possible to calculate all of the badges directly on the frontend. This keeps the badge logic closer to where it's used and avoids adding unnecessary complexity to the synchronisation process.