### PR TITLE
bug: Local date boundary mismatch in historical graph filters excludes boundary day data (#298)

### DIFF
--- a/frontend/js/user/historical-graphs.js
+++ b/frontend/js/user/historical-graphs.js
@@ -75,6 +75,11 @@ function renderRankings(data) {
   }
 }
 
+function parseLocalDate(dateStr) {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  return new Date(year, month - 1, day, 0, 0, 0, 0);
+}
+
 function updateChart() {
   if (!userDataArray || userDataArray.length === 0) {
     return;
@@ -90,24 +95,26 @@ function updateChart() {
   if (currentView === "weekly") {
     filterDate = new Date();
     filterDate.setDate(now.getDate() - 7);
+    filterDate.setHours(0, 0, 0, 0);
   } else if (currentView === "monthly") {
     filterDate = new Date();
     filterDate.setDate(now.getDate() - 30);
+    filterDate.setHours(0, 0, 0, 0);
   }
 
   if (filterDate) {
     let preHistory = userDataArray.filter(
-      (item) => new Date(item.date) < filterDate,
+      (item) => parseLocalDate(item.date) < filterDate,
     );
-    preHistory.sort((a, b) => new Date(a.date) - new Date(b.date));
+    preHistory.sort((a, b) => a.date.localeCompare(b.date));
     if (preHistory.length > 0) {
       const pre = preHistory[preHistory.length - 1];
       baseEasy = Number(pre.easy) || 0;
       baseMedium = Number(pre.medium) || 0;
       baseHard = Number(pre.hard) || 0;
     } else if (userDataArray.length > 0) {
-      const earliest = [...userDataArray].sort(
-        (a, b) => new Date(a.date) - new Date(b.date),
+      const earliest = [...userDataArray].sort((a, b) =>
+        a.date.localeCompare(b.date),
       )[0];
       baseEasy = Number(earliest.easy) || 0;
       baseMedium = Number(earliest.medium) || 0;
@@ -117,7 +124,7 @@ function updateChart() {
 
   if (currentView !== "overall") {
     filteredData = userDataArray.filter(
-      (item) => new Date(item.date) >= filterDate,
+      (item) => parseLocalDate(item.date) >= filterDate,
     );
   } else {
     filteredData = [...userDataArray];
@@ -127,7 +134,7 @@ function updateChart() {
     filteredData = [...userDataArray];
   }
 
-  filteredData.sort((a, b) => new Date(a.date) - new Date(b.date));
+  filteredData.sort((a, b) => a.date.localeCompare(b.date));
 
   const labels = filteredData.map((item) => item.date);
   const easyCounts = filteredData.map((item) =>


### PR DESCRIPTION
## Description

Fixes the timezone offset bug that caused historical performance graphs to omit boundary data points when rendering weekly or monthly progress views. 

The filter threshold `filterDate` was created using client-side local time, while user history records contain dates in `YYYY-MM-DD` strings (which parse in JS as UTC midnight). This mismatch resulted in entries on the boundary date evaluating to `false` for `>= filterDate` comparisons depending on the client's current time of day.

### Linked Issue

Fixes #298

### Changes Made

- Introduced `parseLocalDate(dateStr)` helper to split `YYYY-MM-DD` and construct timezone-independent Date objects starting at local midnight (`00:00:00.000`).
- Normalized `filterDate` to start at local midnight using `setHours(0, 0, 0, 0)` for both weekly (`now - 7 days`) and monthly (`now - 30 days`) filters.
- Optimized graph array sorting to use native string comparisons (`a.date.localeCompare(b.date)`) instead of parsing dates and performing subtraction, improving performance and accuracy.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [x] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording