### PR TITLE
feat: Use live solved counts for today's history entry in fetch-user-info.js (#265)

### DIFF
--- a/scripts/fetch-user-info.js
+++ b/scripts/fetch-user-info.js
@@ -67,11 +67,17 @@ async function fetchUserInfo(username) {
   }
 
   // 2. Fetch live profile ranking from the wrapper API
+  let liveSolved = null;
   const livePromise = fetchWithTimeout(liveApiUrl).then(async (res) => {
     if (res.ok) {
       const apiData = await res.json();
       ranking = apiData.ranking || 0;
       contest = apiData.contest || null;
+      liveSolved = {
+        easy: apiData.easySolved || 0,
+        medium: apiData.mediumSolved || 0,
+        hard: apiData.hardSolved || 0,
+      };
     } else {
       throw new Error(`LeetCode API wrapper returned status ${res.status}`);
     }
@@ -84,6 +90,25 @@ async function fetchUserInfo(username) {
   // Guard against a corrupted history file (e.g. non-array `history` field)
   history = Array.isArray(history) ? history : [];
   history.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+  // Update or append today's entry with live solved counts
+  if (liveSolved) {
+    const today = new Date().toISOString().split("T")[0];
+    let todayEntry = history.find((entry) => entry.date === today);
+    if (!todayEntry) {
+      todayEntry = {
+        date: today,
+        easy: liveSolved.easy,
+        medium: liveSolved.medium,
+        hard: liveSolved.hard,
+      };
+      history.push(todayEntry);
+    } else {
+      todayEntry.easy = liveSolved.easy;
+      todayEntry.medium = liveSolved.medium;
+      todayEntry.hard = liveSolved.hard;
+    }
+  }
 
   return {
     username,

--- a/scripts/fetch-user-info.js
+++ b/scripts/fetch-user-info.js
@@ -86,10 +86,8 @@ async function fetchUserInfo(username) {
   // Wait for the live API task to complete
   await livePromise;
 
-  // Ensure history is sorted chronologically
   // Guard against a corrupted history file (e.g. non-array `history` field)
   history = Array.isArray(history) ? history : [];
-  history.sort((a, b) => new Date(a.date) - new Date(b.date));
 
   // Update or append today's entry with live solved counts
   if (liveSolved) {
@@ -109,6 +107,9 @@ async function fetchUserInfo(username) {
       todayEntry.hard = liveSolved.hard;
     }
   }
+
+  // Ensure history is sorted chronologically after all modifications
+  history.sort((a, b) => new Date(a.date) - new Date(b.date));
 
   return {
     username,


### PR DESCRIPTION
## Description

Previously, the user profile page loaded stale solved count metrics for the current day because historical user data is only updated during the scheduled sync interval (every 15 minutes). 

This PR updates the `/api/user/:username` endpoint to extract live solved counts (`easySolved`, `mediumSolved`, `hardSolved`) from the LeetCode wrapper API and dynamically overwrite (or insert) today's history entry with these live values.

### Linked Issue

Fixes #265

### Changes Made

- Modified `fetchUserInfo()` in `scripts/fetch-user-info.js` to extract `easySolved`, `mediumSolved`, and `hardSolved` counts from the wrapper API response.
- Integrated the live solved counts into today's history entry (using UTC `YYYY-MM-DD` date matching).
- Appends a temporary history entry for today using live counts if the entry does not exist yet (e.g. at the start of a day or for new users).

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [x] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue