### PR TITLE
Fix/chart state mutation

### DIFF
--- a/frontend/js/leaderboard/compare.js
+++ b/frontend/js/leaderboard/compare.js
@@ -705,7 +705,9 @@ function renderProgressHistoryChart() {
       let preHistory = history.filter(
         (item) => new Date(item.date) < filterDate,
       );
-      preHistory.sort((a, b) => new Date(a.date) - new Date(b.date));
+      preHistory = [...preHistory].sort(
+        (a, b) => new Date(a.date) - new Date(b.date),
+      );
       if (preHistory.length > 0) {
         const pre = preHistory[preHistory.length - 1];
         baseTotal =
@@ -715,7 +717,7 @@ function renderProgressHistoryChart() {
       } else if (history.length > 0) {
         // If there's no prehistory but they exist, use their earliest known record in the timeframe
         // to avoid spikes from '0 => total' when their real starting total isn't officially logged exactly before the range.
-        const earliest = history.sort(
+        const earliest = [...history].sort(
           (a, b) => new Date(a.date) - new Date(b.date),
         )[0];
         baseTotal =
@@ -727,7 +729,7 @@ function renderProgressHistoryChart() {
       history = history.filter((item) => new Date(item.date) >= filterDate);
     }
     // Make sure it's sorted chronologically
-    history.sort((a, b) => new Date(a.date) - new Date(b.date));
+    history = [...history].sort((a, b) => new Date(a.date) - new Date(b.date));
     return { username: sh.username, history, baseTotal };
   });
 


### PR DESCRIPTION
## Description
Fixed a bug where `renderProgressHistoryChart` was mutating the global `selectedUserData` state by sorting history arrays in-place. All sorting now uses shallow copies (`[...array].sort()`) to protect the integrity of the original data.

### Linked Issue
Fixes #317

### Changes Made
- Replaced direct `.sort()` calls with `[...array].sort()` in `renderProgressHistoryChart`.
- Protected `preHistory` and `history` arrays from unintended side effects during render.

## Type of Change
- [x] Bug fix

## Testing
- [x] Tested locally
- [x] No console errors introduced

## Checklist
- [x] Follows project style
- [x] Formatted locally
- [x] Submitted from dedicated branch
- [x] Self-reviewed