### PR TITLE
fix: resolve HOT_STREAK badge flickering by excluding today's incomplete data

### DIFF
--- a/frontend/js/user/badges.js
+++ b/frontend/js/user/badges.js
@@ -20,19 +20,44 @@ async function loadBadges(username) {
 
     const earnedSet = new Set();
 
-    if (history.length >= 9) {
-      const recent = history.slice(-9, -1);
-      let streak = true;
+    if (history.length >= 8) {
+      const recent = history.slice(-8, -1);
+      let streak = 0;
+      let isValid = true;
+
       for (let j = 1; j < recent.length; j++) {
         const todayTotals = recent[j].easy + recent[j].medium + recent[j].hard;
         const yesterdayTotals =
           recent[j - 1].easy + recent[j - 1].medium + recent[j - 1].hard;
-        if (todayTotals - yesterdayTotals < 1) {
-          streak = false;
+
+        if (todayTotals - yesterdayTotals >= 1) {
+          streak++;
+        } else {
+          isValid = false;
           break;
         }
       }
-      if (streak) earnedSet.add("HOT_STREAK");
+
+      if (isValid) {
+        const currentDay = history[history.length - 1];
+        const previousDay = history[history.length - 2];
+        const solvedToday =
+          currentDay.easy +
+            currentDay.medium +
+            currentDay.hard -
+            (previousDay.easy + previousDay.medium + previousDay.hard) >=
+          1;
+
+        if (solvedToday) {
+          streak++;
+        }
+      } else {
+        streak = 0;
+      }
+
+      if (streak >= 7) {
+        earnedSet.add("HOT_STREAK");
+      }
     }
 
     if (ranks.overall && parseInt(ranks.overall.change, 10) >= 5) {

--- a/frontend/js/user/badges.js
+++ b/frontend/js/user/badges.js
@@ -20,8 +20,8 @@ async function loadBadges(username) {
 
     const earnedSet = new Set();
 
-    if (history.length >= 8) {
-      const recent = history.slice(-8);
+    if (history.length >= 9) {
+      const recent = history.slice(-9, -1);
       let streak = true;
       for (let j = 1; j < recent.length; j++) {
         const todayTotals = recent[j].easy + recent[j].medium + recent[j].hard;


### PR DESCRIPTION
## Description

This PR fixes an issue where the `HOT_STREAK` badge would prematurely disappear or flicker on the current calendar day. Previously, the streak calculation included today's incomplete data in its evaluation, causing the badge to be withheld until a problem was solved. By adjusting the history slice to look at the last 8 days excluding the current incomplete day, the badge now remains correctly visible throughout the day for users with an active streak.

### Linked Issue

Fixes #269

### Changes Made

- Modified `loadBadges` function logic.
- Updated the `history` slice window from `(-8)` to `(-9, -1)` to exclude today's incomplete data from the `HOT_STREAK` calculation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally (using real user history and verified badge persistence)
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

N/A