### PR TITLE
feat: implement incremental streak tracking and backfill initialization

### DIFF
--- a/scripts/backfill-streaks.js
+++ b/scripts/backfill-streaks.js
@@ -1,0 +1,83 @@
+"use strict";
+
+const fs = require("fs").promises;
+const fsSync = require("fs");
+const path = require("path");
+
+async function calculateStreaks(history) {
+  if (!history || history.length === 0) {
+    return { currentStreak: 0, longestStreak: 0, lastUpdated: null };
+  }
+
+  const sortedHistory = [...history].sort(
+    (a, b) => new Date(a.date) - new Date(b.date),
+  );
+
+  let currentStreak = 0;
+  let longestStreak = 0;
+  let lastActiveDate = null;
+  let previousTotal = -1;
+
+  for (const entry of sortedHistory) {
+    const currentTotal =
+      (entry.easy || 0) + (entry.medium || 0) + (entry.hard || 0);
+    const entryDate = new Date(entry.date);
+
+    if (currentTotal > previousTotal) {
+      if (!lastActiveDate) {
+        currentStreak = 1;
+      } else {
+        const diffDays = Math.round(
+          (entryDate - lastActiveDate) / (1000 * 60 * 60 * 24),
+        );
+
+        if (diffDays === 1) {
+          currentStreak++;
+        } else if (diffDays > 1) {
+          currentStreak = 1;
+        }
+      }
+
+      longestStreak = Math.max(longestStreak, currentStreak);
+      lastActiveDate = entryDate;
+    }
+
+    previousTotal = currentTotal;
+  }
+
+  return {
+    currentStreak,
+    longestStreak,
+    lastUpdated: lastActiveDate
+      ? lastActiveDate.toISOString().split("T")[0]
+      : null,
+  };
+}
+
+async function runBackfill() {
+  const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, "..", "data");
+  const userDataDir = path.join(DATA_DIR, "user-data");
+
+  try {
+    const files = await fs.readdir(userDataDir);
+    const jsonFiles = files.filter((f) => f.endsWith(".json"));
+
+    for (const file of jsonFiles) {
+      const filePath = path.join(userDataDir, file);
+      const userData = JSON.parse(await fs.readFile(filePath, "utf8"));
+
+      const streaks = await calculateStreaks(userData.history);
+
+      userData.currentStreak = streaks.currentStreak;
+      userData.longestStreak = streaks.longestStreak;
+      userData.streakLastUpdated = streaks.lastUpdated;
+
+      await fs.writeFile(filePath, JSON.stringify(userData, null, 2));
+    }
+  } catch (err) {
+    console.error(`Backfill failed: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+runBackfill();

--- a/scripts/backfill-streaks.js
+++ b/scripts/backfill-streaks.js
@@ -68,9 +68,11 @@ async function runBackfill() {
 
       const streaks = await calculateStreaks(userData.history);
 
-      userData.currentStreak = streaks.currentStreak;
-      userData.longestStreak = streaks.longestStreak;
-      userData.streakLastUpdated = streaks.lastUpdated;
+      userData.streak = {
+        current: streaks.currentStreak,
+        longest: streaks.longestStreak,
+        lastUpdated: streaks.lastUpdated,
+      };
 
       await fs.writeFile(filePath, JSON.stringify(userData, null, 2));
     }

--- a/scripts/backfill-streaks.js
+++ b/scripts/backfill-streaks.js
@@ -6,7 +6,7 @@ const path = require("path");
 
 async function calculateStreaks(history) {
   if (!history || history.length === 0) {
-    return { currentStreak: 0, longestStreak: 0, lastUpdated: null };
+    return { currentStreak: 0, longestStreak: 0, lastActiveDate: null };
   }
 
   const sortedHistory = [...history].sort(
@@ -48,7 +48,7 @@ async function calculateStreaks(history) {
   return {
     currentStreak,
     longestStreak,
-    lastUpdated: lastActiveDate
+    lastActiveDate: lastActiveDate
       ? lastActiveDate.toISOString().split("T")[0]
       : null,
   };
@@ -71,7 +71,7 @@ async function runBackfill() {
       userData.streak = {
         current: streaks.currentStreak,
         longest: streaks.longestStreak,
-        lastUpdated: streaks.lastUpdated,
+        lastActiveDate: streaks.lastActiveDate,
       };
 
       await fs.writeFile(filePath, JSON.stringify(userData, null, 2));

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -95,6 +95,40 @@ async function updateUserDataAsync(user, DATA_DIR, ranksObj = null) {
   if (ranksObj) {
     userData.leaderboardRanks = ranksObj;
   }
+
+  const today = new Date().toISOString().split("T")[0];
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  const yesterdayStr = yesterday.toISOString().split("T")[0];
+
+  const totalSolvedToday =
+    (user.data.easySolved || 0) +
+    (user.data.mediumSolved || 0) +
+    (user.data.hardSolved || 0);
+
+  const totalSolvedYesterday =
+    history.length > 1
+      ? history[history.length - 2].easy +
+        history[history.length - 2].medium +
+        history[history.length - 2].hard
+      : 0;
+
+  if (userData.streakLastUpdated && userData.streakLastUpdated < yesterdayStr) {
+    userData.currentStreak = 0;
+  }
+
+  if (
+    totalSolvedToday > totalSolvedYesterday &&
+    userData.streakLastUpdated !== today
+  ) {
+    userData.currentStreak = (userData.currentStreak || 0) + 1;
+    userData.streakLastUpdated = today;
+
+    if (userData.currentStreak > (userData.longestStreak || 0)) {
+      userData.longestStreak = userData.currentStreak;
+    }
+  }
+
   await atomicWrite(userDataPath, userData);
 }
 

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -101,6 +101,10 @@ async function updateUserDataAsync(user, DATA_DIR, ranksObj = null) {
   yesterday.setDate(yesterday.getDate() - 1);
   const yesterdayStr = yesterday.toISOString().split("T")[0];
 
+  if (!userData.streak) {
+    userData.streak = { current: 0, longest: 0, lastUpdated: null };
+  }
+
   const totalSolvedToday =
     (user.data.easySolved || 0) +
     (user.data.mediumSolved || 0) +
@@ -113,19 +117,22 @@ async function updateUserDataAsync(user, DATA_DIR, ranksObj = null) {
         history[history.length - 2].hard
       : 0;
 
-  if (userData.streakLastUpdated && userData.streakLastUpdated < yesterdayStr) {
-    userData.currentStreak = 0;
+  if (
+    userData.streak.lastUpdated &&
+    userData.streak.lastUpdated < yesterdayStr
+  ) {
+    userData.streak.current = 0;
   }
 
   if (
     totalSolvedToday > totalSolvedYesterday &&
-    userData.streakLastUpdated !== today
+    userData.streak.lastUpdated !== today
   ) {
-    userData.currentStreak = (userData.currentStreak || 0) + 1;
-    userData.streakLastUpdated = today;
+    userData.streak.current += 1;
+    userData.streak.lastUpdated = today;
 
-    if (userData.currentStreak > (userData.longestStreak || 0)) {
-      userData.longestStreak = userData.currentStreak;
+    if (userData.streak.current > (userData.streak.longest || 0)) {
+      userData.streak.longest = userData.streak.current;
     }
   }
 

--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -102,7 +102,7 @@ async function updateUserDataAsync(user, DATA_DIR, ranksObj = null) {
   const yesterdayStr = yesterday.toISOString().split("T")[0];
 
   if (!userData.streak) {
-    userData.streak = { current: 0, longest: 0, lastUpdated: null };
+    userData.streak = { current: 0, longest: 0, lastActiveDate: null };
   }
 
   const totalSolvedToday =
@@ -118,18 +118,18 @@ async function updateUserDataAsync(user, DATA_DIR, ranksObj = null) {
       : 0;
 
   if (
-    userData.streak.lastUpdated &&
-    userData.streak.lastUpdated < yesterdayStr
+    userData.streak.lastActiveDate &&
+    userData.streak.lastActiveDate < yesterdayStr
   ) {
     userData.streak.current = 0;
   }
 
   if (
     totalSolvedToday > totalSolvedYesterday &&
-    userData.streak.lastUpdated !== today
+    userData.streak.lastActiveDate !== today
   ) {
     userData.streak.current += 1;
-    userData.streak.lastUpdated = today;
+    userData.streak.lastActiveDate = today;
 
     if (userData.streak.current > (userData.streak.longest || 0)) {
       userData.streak.longest = userData.streak.current;


### PR DESCRIPTION
## Description

Implemented incremental streak tracking to enhance user engagement. This PR introduces a backend utility to calculate streak history and updates the sync process to use constant-time (O(1)) logic, avoiding expensive full-history scans during every 15-minute sync.

### Linked Issue

Related to #51 

### Changes Made

- Added `scripts/backfill-streaks.js` to calculate and initialize `currentStreak`, `longestStreak`, and `streakLastUpdated` for existing users.
- Updated `sync-leaderboard.js` to include incremental streak logic (Step A: Check for broken streak, Step B & C: Detect activity and update streak).
- Added logic to persist streak metadata in user-specific JSON files.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

N/A