### PR TITLE
docs: add leaderboard synchronization note

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Students can register using their LeetCode username to participate in the leader
 
 Leaderboard data is synchronized periodically, so newly registered users and recent submissions may take a few minutes to appear in the rankings.
 
+> **Tip:** If your profile does not appear immediately after registration, wait for the next synchronization cycle before attempting to register again.
+
 ---
 
 ## How to Run Locally


### PR DESCRIPTION
## Description

Added a documentation tip explaining that leaderboard updates are synchronized periodically and advising users to wait for the next sync cycle before attempting to register again if their profile does not appear immediately.

### Linked Issue

Fixes #None (just a documentation quick fix)

### Changes Made

- Added a helpful note about leaderboard synchronization.
- Improved the README by setting clear expectations for newly registered users.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [x] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [ ] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

Not applicable (documentation-only change).