### PR TITLE
feat: display all possible badges with locked state and updated styles

### DIFF
--- a/frontend/js/user/badges.js
+++ b/frontend/js/user/badges.js
@@ -65,7 +65,7 @@ async function loadBadges(username) {
       }
     }
 
-   ALL_BADGES.forEach((badgeDef) => {
+    ALL_BADGES.forEach((badgeDef) => {
       const isEarned = earnedSet.has(badgeDef.id);
       const badge = document.createElement("div");
       const safeClass = badgeDef.id.toLowerCase().replace(/_/g, "");
@@ -84,7 +84,6 @@ async function loadBadges(username) {
     console.error("Error loading user badges:", err);
   }
 }
-
 
 document.addEventListener("DOMContentLoaded", () => {
   const pathSegments = window.location.pathname.split("/");

--- a/frontend/js/user/badges.js
+++ b/frontend/js/user/badges.js
@@ -65,19 +65,18 @@ async function loadBadges(username) {
       }
     }
 
-    if (earnedSet.size === 0) return;
-
-    earnedSet.forEach((badgeId) => {
+   ALL_BADGES.forEach((badgeDef) => {
+      const isEarned = earnedSet.has(badgeDef.id);
       const badge = document.createElement("div");
+      const safeClass = badgeDef.id.toLowerCase().replace(/_/g, "");
 
-      const badgeDef = ALL_BADGES.find((b) => b.id === badgeId);
-      const safeClass = badgeId.toLowerCase().replace("_", "");
+      // Apply locked class if the user hasn't earned it
+      badge.className = isEarned
+        ? `badge badge-${safeClass}`
+        : `badge badge-${safeClass} badge-locked`;
 
-      badge.className = `badge badge-${safeClass}`;
-      badge.textContent = `[${badgeId}]`;
-      if (badgeDef) {
-        badge.setAttribute("data-title", badgeDef.title);
-      }
+      badge.textContent = `${badgeDef.id}`;
+      badge.setAttribute("data-title", badgeDef.title);
 
       badgeWall.appendChild(badge);
     });
@@ -85,6 +84,7 @@ async function loadBadges(username) {
     console.error("Error loading user badges:", err);
   }
 }
+
 
 document.addEventListener("DOMContentLoaded", () => {
   const pathSegments = window.location.pathname.split("/");

--- a/frontend/user.html
+++ b/frontend/user.html
@@ -223,7 +223,14 @@
         border-color: rgba(0, 229, 255, 0.3);
         text-shadow: 0 0 5px rgba(0, 229, 255, 0.3);
       }
-
+.badge.badge-locked {
+        opacity: 0.4;
+        border-style: dashed;
+        filter: grayscale(80%);
+        color: var(--text-dim, #888);
+        background: rgba(255, 255, 255, 0.03);
+        text-shadow: none;
+      }
       .badge[data-title]:hover::after,
       .rank-change[data-title]:hover::after {
         content: attr(data-title);

--- a/frontend/user.html
+++ b/frontend/user.html
@@ -223,7 +223,7 @@
         border-color: rgba(0, 229, 255, 0.3);
         text-shadow: 0 0 5px rgba(0, 229, 255, 0.3);
       }
-.badge.badge-locked {
+      .badge.badge-locked {
         opacity: 0.4;
         border-style: dashed;
         filter: grayscale(80%);


### PR DESCRIPTION
## Description

Implemented the requested badge wall feature to display all possible badges (both earned and unearned/locked) in the user profile. Locked badges are visually distinct with a dashed border, reduced opacity, and grayscale styling to gamify the user experience and encourage participation.

### Linked Issue

Fixes #330  

### Changes Made

- Updated `badges.js` to iterate over the entire `ALL_BADGES` master list instead of returning early when no badges are earned.
- Added conditional checks to apply the `.badge-locked` CSS class and clean badge text IDs for locked states.
- Updated styles in the CSS stylesheet to support the `.badge.badge-locked` state with dashed borders, opacity, and dimmed colors while preserving the terminal aesthetic.

## Type of Change

- [x] New feature
- [x] UI/Visual update

## Testing

- [x] Tested locally
- [x] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

<!-- Required for UI/Visual changes whenever possible -->