### PR TITLE
feat(leaderboard): add statistics modal with aggregate metrics

### DIFF
--- a/frontend/js/leaderboard/stats.js
+++ b/frontend/js/leaderboard/stats.js
@@ -1,0 +1,219 @@
+/**
+ * CodePVG Leaderboard Statistics Module
+ * Computes and renders aggregate statistics from existing leaderboard data.
+ * Frontend-only: reuses window.leaderboardData, no new API calls.
+ */
+
+let statsGraphRange = "overall";
+let statsDifficultyChartInstance = null;
+
+document.addEventListener("DOMContentLoaded", () => {
+  const toggleBtn = document.getElementById("stats-modal-toggle");
+  if (toggleBtn) {
+    toggleBtn.addEventListener("click", openStatsModal);
+  }
+
+  const closeBtn = document.getElementById("close-stats-modal");
+  if (closeBtn) {
+    closeBtn.addEventListener("click", closeStatsModal);
+  }
+
+  const modalOverlay = document.getElementById("stats-modal");
+  if (modalOverlay) {
+    modalOverlay.addEventListener("click", (e) => {
+      if (e.target === modalOverlay) {
+        closeStatsModal();
+      }
+    });
+  }
+
+  const rangeButtons = {
+    overall: document.getElementById("stats-btn-overall"),
+    monthly: document.getElementById("stats-btn-monthly"),
+    weekly: document.getElementById("stats-btn-weekly"),
+    daily: document.getElementById("stats-btn-daily"),
+  };
+
+  Object.keys(rangeButtons).forEach((range) => {
+    const btn = rangeButtons[range];
+    if (btn) {
+      btn.addEventListener("click", () => {
+        statsGraphRange = range;
+        updateStatsRangeButtons();
+        updateStatsModalTitle();
+        renderStats();
+      });
+    }
+  });
+});
+
+function updateStatsRangeButtons() {
+  const rangeButtons = {
+    overall: document.getElementById("stats-btn-overall"),
+    monthly: document.getElementById("stats-btn-monthly"),
+    weekly: document.getElementById("stats-btn-weekly"),
+    daily: document.getElementById("stats-btn-daily"),
+  };
+  Object.values(rangeButtons).forEach(
+    (b) => b && b.classList.remove("active-filter"),
+  );
+  if (rangeButtons[statsGraphRange]) {
+    rangeButtons[statsGraphRange].classList.add("active-filter");
+  }
+}
+
+function updateStatsModalTitle() {
+  const titleEl = document.getElementById("stats-modal-title");
+  if (titleEl) {
+    titleEl.textContent = `[SYSTEM_STATS_MODULE] - metrics_summary (${statsGraphRange})`;
+  }
+}
+
+/**
+ * Opens the statistics overlay, defaulting to whichever leaderboard mode
+ * is currently active, then renders from already-loaded leaderboardData.
+ */
+function openStatsModal() {
+  const modal = document.getElementById("stats-modal");
+  if (!modal) return;
+
+  statsGraphRange =
+    (typeof activeDatasetType !== "undefined" && activeDatasetType) ||
+    "overall";
+  updateStatsRangeButtons();
+  updateStatsModalTitle();
+
+  modal.classList.add("active");
+  renderStats();
+}
+
+function closeStatsModal() {
+  const modal = document.getElementById("stats-modal");
+  if (modal) {
+    modal.classList.remove("active");
+  }
+
+  if (statsDifficultyChartInstance) {
+    statsDifficultyChartInstance.destroy();
+    statsDifficultyChartInstance = null;
+  }
+}
+
+/**
+ * Computes aggregate stats for the current mode from window.leaderboardData
+ */
+function computeAggregateStats(mode) {
+  const dataset =
+    (window.leaderboardData && window.leaderboardData[mode]) || [];
+
+  const totalRegisteredUsers = dataset.length;
+
+  let totalSolved = 0;
+  let totalEasy = 0;
+  let totalMedium = 0;
+  let totalHard = 0;
+
+  dataset.forEach((user) => {
+    const d = user.data || {};
+    totalSolved += Number(d.totalSolved) || 0;
+    totalEasy += Number(d.easySolved) || 0;
+    totalMedium += Number(d.mediumSolved) || 0;
+    totalHard += Number(d.hardSolved) || 0;
+  });
+
+  const avgSolvedPerUser =
+    totalRegisteredUsers > 0
+      ? (totalSolved / totalRegisteredUsers).toFixed(2)
+      : "0.00";
+
+  return {
+    totalRegisteredUsers,
+    totalSolved,
+    avgSolvedPerUser,
+    totalEasy,
+    totalMedium,
+    totalHard,
+  };
+}
+
+/**
+ * Renders the metrics table for the currently selected mode
+ */
+function populateStatsTable(stats) {
+  const table = document.getElementById("stats-table-el");
+  if (!table) return;
+
+  table.innerHTML = "";
+
+  const rows = [
+    ["Total Registered Users", stats.totalRegisteredUsers],
+    ["Total Problems Solved", stats.totalSolved],
+    ["Avg. Problems Solved / User", stats.avgSolvedPerUser],
+    ["Easy Solved (aggregate)", stats.totalEasy],
+    ["Medium Solved (aggregate)", stats.totalMedium],
+    ["Hard Solved (aggregate)", stats.totalHard],
+  ];
+
+  const tbody = document.createElement("tbody");
+  rows.forEach(([label, value]) => {
+    const row = document.createElement("tr");
+    const labelCell = document.createElement("td");
+    labelCell.textContent = label;
+    const valueCell = document.createElement("td");
+    valueCell.textContent = value;
+    row.appendChild(labelCell);
+    row.appendChild(valueCell);
+    tbody.appendChild(row);
+  });
+
+  table.appendChild(tbody);
+}
+
+/**
+ * Renders the aggregate Easy/Medium/Hard distribution as a doughnut chart
+ */
+function renderStatsDifficultyChart(stats) {
+  const canvas = document.getElementById("statsDifficultyChart");
+  if (!canvas) return;
+
+  const ctx = canvas.getContext("2d");
+  if (statsDifficultyChartInstance) {
+    statsDifficultyChartInstance.destroy();
+  }
+
+  statsDifficultyChartInstance = new Chart(ctx, {
+    type: "doughnut",
+    data: {
+      labels: ["Easy", "Medium", "Hard"],
+      datasets: [
+        {
+          data: [stats.totalEasy, stats.totalMedium, stats.totalHard],
+          backgroundColor: ["#00ff41", "#ffb000", "#ff3333"],
+          borderColor: ["#00cc33", "#cc8e00", "#cc0000"],
+          borderWidth: 1,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          labels: {
+            color: "#b0ffb0",
+            font: { family: "Fira Code" },
+          },
+        },
+      },
+    },
+  });
+}
+
+/**
+ * Recomputes and redraws the entire stats view for statsGraphRange
+ */
+function renderStats() {
+  const stats = computeAggregateStats(statsGraphRange);
+  populateStatsTable(stats);
+  renderStatsDifficultyChart(stats);
+}

--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -22,6 +22,7 @@
       nonce="__NONCE__"
     ></script>
     <script src="/js/leaderboard/compare.js" nonce="__NONCE__"></script>
+    <script src="/js/leaderboard/stats.js" nonce="__NONCE__"></script>
 
     <meta
       name="description"
@@ -159,6 +160,26 @@
             margin-bottom: 0.5rem;
           "
         >
+          <button
+            type="button"
+            id="stats-modal-toggle"
+            style="
+              background: var(--bg-raised);
+              border: 1px solid var(--border);
+              border-bottom: 1px solid var(--border-bright);
+              color: var(--cyan);
+              font-family: inherit;
+              font-size: 0.82rem;
+              cursor: pointer;
+              transition: all 0.2s ease;
+              padding: 3px 10px;
+              border-radius: 4px;
+              margin-right: 0.5rem;
+              white-space: nowrap;
+            "
+          >
+            [--statistics]
+          </button>
           <button
             type="button"
             id="compare-mode-toggle"
@@ -732,6 +753,113 @@
         applyFiltersAndRender();
       }
     </script>
+
+    <!-- Statistics Modal Overlay -->
+    <div id="stats-modal" class="compare-modal-overlay">
+      <div class="compare-card">
+        <div class="compare-card-header">
+          <span class="compare-card-title" id="stats-modal-title"
+            >[SYSTEM_STATS_MODULE] - metrics_summary (overall)</span
+          >
+          <button id="close-stats-modal" class="compare-card-close">
+            [DISMISS]
+          </button>
+        </div>
+
+        <div class="compare-card-body">
+          <div
+            class="compare-results"
+            id="stats-results"
+            style="display: block"
+          >
+            <!-- Mode filter buttons -->
+            <div
+              style="
+                display: flex;
+                gap: 10px;
+                flex-wrap: wrap;
+                margin: 0 0 1.5rem 0;
+                justify-content: center;
+              "
+            >
+              <button
+                id="stats-btn-overall"
+                class="btn btn-secondary active-filter"
+                style="
+                  min-width: unset;
+                  width: auto;
+                  padding: 0.4rem 1rem;
+                  font-size: 0.8rem;
+                  margin: 0;
+                  font-family: &quot;Fira Code&quot;, monospace;
+                "
+              >
+                Overall
+              </button>
+              <button
+                id="stats-btn-monthly"
+                class="btn btn-secondary"
+                style="
+                  min-width: unset;
+                  width: auto;
+                  padding: 0.4rem 1rem;
+                  font-size: 0.8rem;
+                  margin: 0;
+                  font-family: &quot;Fira Code&quot;, monospace;
+                "
+              >
+                Monthly
+              </button>
+              <button
+                id="stats-btn-weekly"
+                class="btn btn-secondary"
+                style="
+                  min-width: unset;
+                  width: auto;
+                  padding: 0.4rem 1rem;
+                  font-size: 0.8rem;
+                  margin: 0;
+                  font-family: &quot;Fira Code&quot;, monospace;
+                "
+              >
+                Weekly
+              </button>
+              <button
+                id="stats-btn-daily"
+                class="btn btn-secondary"
+                style="
+                  min-width: unset;
+                  width: auto;
+                  padding: 0.4rem 1rem;
+                  font-size: 0.8rem;
+                  margin: 0;
+                  font-family: &quot;Fira Code&quot;, monospace;
+                "
+              >
+                Daily
+              </button>
+            </div>
+
+            <!-- Metrics Table (reuses compare-table styling) -->
+            <div style="overflow-x: auto; margin-bottom: 1rem">
+              <table class="compare-table" id="stats-table-el">
+                <!-- Dynamically populated -->
+              </table>
+            </div>
+
+            <!-- Difficulty distribution chart -->
+            <div class="compare-charts-row">
+              <div class="compare-chart-card" style="flex: 1 1 100%">
+                <div class="compare-chart-title">
+                  // AGGREGATE_DIFFICULTY_DISTRIBUTION
+                </div>
+                <canvas id="statsDifficultyChart"></canvas>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
 
     <!-- User Comparison Modal Overlay -->
     <div id="compare-modal" class="compare-modal-overlay">


### PR DESCRIPTION
## Description
Adds a Statistics Modal to the leaderboard, giving users an aggregate overview (total users, total solved, averages, difficulty distribution) without leaving the page — implemented entirely on the frontend per the issue's constraints.

### Linked Issue
Fixes #296

### Changes Made
- Added a `[--statistics]` button beside the existing `[--compare-peers]` button on the leaderboard
- Added a new Statistics modal (`#stats-modal`) that reuses the existing `.compare-card` / `.compare-modal-overlay` styling for visual consistency with the Compare Peers modal
- Created `frontend/js/leaderboard/stats.js` which computes aggregate stats from `window.leaderboardData` (already loaded by the page — no new fetch or endpoint):
  - Total registered users
  - Total problems solved
  - Average problems solved per user
  - Easy / Medium / Hard solve distribution, shown as both a table and a doughnut chart
- Added mode-switch buttons inside the modal (Overall / Monthly / Weekly / Daily) that recompute and re-render stats without closing the modal
- Ran `npx prettier --write` on all changed files

## Type of Change
- [x] New feature

## Testing
- [ ] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [ ] No console errors introduced

### How to test
1. Open the leaderboard page and click `[--statistics]`
2. Confirm the modal opens showing stats for whichever tab (Overall/Monthly/Weekly/Daily) is currently active on the main leaderboard
3. Click the mode buttons inside the modal and confirm the table and chart update without the modal closing
4. Confirm no new network requests fire when opening the modal or switching modes (Network tab) — data should come entirely from already-loaded `window.leaderboardData`
5. Confirm `[--compare-peers]` still works unaffected

## Checklist
- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

