### PR TITLE
fix: make registration input wrapper focus input on click

### DIFF
--- a/frontend/js/terminal_ui.js
+++ b/frontend/js/terminal_ui.js
@@ -57,6 +57,13 @@ document.addEventListener("DOMContentLoaded", () => {
     wrapper.appendChild(input);
     wrapper.appendChild(suffix);
 
+    // Focus the input when clicking anywhere inside the wrapper
+    wrapper.addEventListener("click", (e) => {
+      if (e.target !== input) {
+        input.focus();
+      }
+    });
+
     // Remove structural borders from the input so the flex wrapper handles all boundaries
     input.classList.add("bash-active");
 


### PR DESCRIPTION
## Description

Fixed the registration input focus issue by making the entire visible input wrapper clickable. Clicking anywhere inside the input container now focuses the corresponding input while preserving the existing terminal-style UI and behavior.

### Linked Issue

Fixes #322

### Changes Made

- Added a click event listener to the dynamically created `.form-input-bash-wrapper`.
- Clicking anywhere inside the wrapper now focuses the associated input field.
- Preserved the existing UI, typing animation, validation, and styling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue


