### PR TITLE
fix: preserve leaderboard timeframe in compare modal

### DIFF
--- a/frontend/leaderboard.html
+++ b/frontend/leaderboard.html
@@ -408,6 +408,7 @@
       let currentPage = 1;
       let itemsPerPage = 25;
       let activeDatasetType = "overall";
+      window.activeDatasetType = "overall";
       let currentSearchTerm = "";
 
       async function fetchLeaderboardData() {
@@ -719,6 +720,7 @@
         }
 
         activeDatasetType = activeTab;
+        window.activeDatasetType = activeTab;
         currentPage = 1;
 
         document.querySelectorAll(".tab").forEach((tab) => {


### PR DESCRIPTION
## Description

Fixes #345.

The Compare Modal now inherits the currently selected leaderboard timeframe instead of defaulting to Overall.

The active leaderboard timeframe is exposed through `window.activeDatasetType`, allowing the existing Compare Modal logic to initialize with the correct graph range.

## Changes

- Expose the initial leaderboard timeframe through `window.activeDatasetType`.
- Keep `window.activeDatasetType` synchronized when switching leaderboard tabs.
- Preserve existing manual timeframe switching inside the Compare Modal.

## Testing

Manually verified:

- Overall leaderboard → Compare Modal opens on Overall
- Monthly leaderboard → Compare Modal opens on Monthly
- Weekly leaderboard → Compare Modal opens on Weekly
- Daily leaderboard → Compare Modal opens on Daily
- Manual switching between timeframes inside the open Compare Modal continues to work correctly