### PR TITLE
Fix: add box-shadow: none to .badge.badge-locked (#371)

### DIFF
--- a/frontend/user.html
+++ b/frontend/user.html
@@ -250,6 +250,7 @@
         color: var(--text-dim, #888);
         background: rgba(255, 255, 255, 0.03);
         text-shadow: none;
+        box-shadow: none;
       }
       .badge[data-title]:hover::after,
       .rank-change[data-title]:hover::after {


### PR DESCRIPTION
## Description
Fixes a CSS specificity/override gap where the .badge.badge-locked class did not fully neutralize badge-specific visual effects. Specifically, the TOP_BRASS badge (.badge-topbrass) defines its own box-shadow (a white glow), but .badge.badge-locked never declared a box-shadow override — so locked TOP_BRASS badges retained their glow instead of appearing consistently greyed-out like other locked badges.
<!-- Please include a summary of the change and what problem it solves. -->

### Linked Issue
Fixes #371

### Changes Made
-Added `box-shadow: none`; to the `.badge.badge-locked` rule in` frontend/user.html`.
-Reviewed the other badge variants (`hotstreak, speedrun, hardcarry, centurion, uplink`) to confirm none of them declare` box-shadow`, so `TOP_BRASS `was the only badge affected by this gap.
<!-- Briefly describe the key changes made in this PR. -->

## Type of Change

<!-- Put an 'x' inside the brackets that apply -->

- [x ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing
Verified by toggling the `badge-locked` class on a` .badge-topbrass` element in DevTools , the glow no longer appears, and locked badges now render consistently across all variants. Spot-checked locked `hotstreak` and `uplink` badges to confirm no regressions.
- [x ] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x ] No console errors introduced

## Checklist

- [ x] My code follows the project's coding style
- [ x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x ] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [ x] I have performed a self-review of my code
- [ x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [ x] I have linked the relevant issue

## Screenshots / Screen Recording

<img width="1600" height="872" alt="WhatsApp Image 2026-07-30 at 1 36 24 AM" src="https://github.com/user-attachments/assets/2787d729-c22a-4103-9fd3-3c0db1027ea9" />
