### PR TITLE
feat: implement safeUntil state cache in analyze-inactivity script

### DIFF
--- a/scripts/analyze-inactivity.js
+++ b/scripts/analyze-inactivity.js
@@ -49,10 +49,22 @@ async function fetchData(url) {
     process.exit(1);
   }
 
+  const stateFilePath = path.join(DATA_DIR, "activity-state.json");
+  let activityState = {};
+  try {
+    if (fs.existsSync(stateFilePath)) {
+      activityState = JSON.parse(fs.readFileSync(stateFilePath, "utf8"));
+      console.log("Loaded activity-state.json cache.");
+    }
+  } catch (err) {
+    console.warn("Failed to load activity-state.json, starting fresh cache.");
+  }
+
   const baseUrl = "https://leetcode-api-dun.vercel.app/";
   const inactiveUsers = [];
   const unreachableUsers = [];
   const now = new Date();
+  const currentTimeMs = now.getTime();
 
   console.log(" ");
   console.log("Starting daily full sync inactivity analysis...");
@@ -65,6 +77,12 @@ async function fetchData(url) {
     await Promise.all(
       batch.map(async (user) => {
         const username = user.id;
+        const cachedRecord = activityState[username];
+
+        if (cachedRecord && cachedRecord.safeUntil && currentTimeMs < cachedRecord.safeUntil) {
+          console.log(`${username}: Active (Skipped via cache, safe until ${new Date(cachedRecord.safeUntil).toISOString().split('T')[0]})`);
+          return;
+        }
 
         const profile = await fetchData(baseUrl + username);
         if (!profile) {
@@ -87,6 +105,13 @@ async function fetchData(url) {
 
         const diffTime = Math.abs(now - lastActiveDate);
         const diffDays = Math.floor(diffTime / MS_IN_A_DAY);
+
+        const safeUntilTimeMs = (latestTimestampSeconds * 1000) + (THRESHOLD_DAYS * MS_IN_A_DAY);
+
+        activityState[username] = {
+          safeUntil: safeUntilTimeMs,
+          lastChecked: currentTimeMs,
+        };
 
         if (diffDays > THRESHOLD_DAYS) {
           console.log(`${username}: Inactive (${diffDays} days ago)`);
@@ -115,6 +140,15 @@ async function fetchData(url) {
     console.log("Inactivity analysis data updated successfully!");
   } catch (err) {
     console.error("Failed to write inactive-users.json: ", err.message);
+    process.exit(1);
+  }
+
+  console.log("Writing activity state cache to activity-state.json...");
+  try {
+    atomicWrite(stateFilePath, activityState);
+    console.log("Activity state cache updated successfully!");
+  } catch (err) {
+    console.error("Failed to write activity-state.json: ", err.message);
     process.exit(1);
   }
 })();

--- a/scripts/analyze-inactivity.js
+++ b/scripts/analyze-inactivity.js
@@ -79,8 +79,14 @@ async function fetchData(url) {
         const username = user.id;
         const cachedRecord = activityState[username];
 
-        if (cachedRecord && cachedRecord.safeUntil && currentTimeMs < cachedRecord.safeUntil) {
-          console.log(`${username}: Active (Skipped via cache, safe until ${new Date(cachedRecord.safeUntil).toISOString().split('T')[0]})`);
+        if (
+          cachedRecord &&
+          cachedRecord.safeUntil &&
+          currentTimeMs < cachedRecord.safeUntil
+        ) {
+          console.log(
+            `${username}: Active (Skipped via cache, safe until ${new Date(cachedRecord.safeUntil).toISOString().split("T")[0]})`,
+          );
           return;
         }
 
@@ -106,7 +112,8 @@ async function fetchData(url) {
         const diffTime = Math.abs(now - lastActiveDate);
         const diffDays = Math.floor(diffTime / MS_IN_A_DAY);
 
-        const safeUntilTimeMs = (latestTimestampSeconds * 1000) + (THRESHOLD_DAYS * MS_IN_A_DAY);
+        const safeUntilTimeMs =
+          latestTimestampSeconds * 1000 + THRESHOLD_DAYS * MS_IN_A_DAY;
 
         activityState[username] = {
           safeUntil: safeUntilTimeMs,


### PR DESCRIPTION
## Description

Implemented a state cache (`data/activity-state.json`) in the inactivity analysis script (`scripts/analyze-inactivity.js`) to track `safeUntil` timestamps for active users. This completely skips unnecessary LeetCode API polling for users who are mathematically guaranteed to remain active within their 90-day padding window, saving massive amounts of compute time and preventing rate limits.

### Linked Issue

Fixes #337

### Changes Made

- Added logic to load and save `data/activity-state.json` safely using the project's atomic write utility.
- Integrated a cache validation check inside the concurrency loop to skip `fetchData` calls if `Date.now() < safeUntil`.
- Automatically calculated and stored the new `safeUntil` boundary (`latestTimestamp + 90 days`) for users who undergo an active profile fetch.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording