### PR TITLE
fix: don't flag every user as NEW when yesterday snapshot is unavailable

### DIFF
--- a/scripts/sync-leaderboard.js
+++ b/scripts/sync-leaderboard.js
@@ -204,11 +204,25 @@ async function computeRankChanges(currentSorted, filename) {
   let previousRanks = {};
   const previousData = await getYesterdaySnapshot(filename);
 
-  if (previousData && Array.isArray(previousData)) {
-    previousData.forEach((user, idx) => {
-      previousRanks[user.id] = user.originalRank || idx + 1;
+  // getYesterdaySnapshot() returns null on ANY error (network, GitHub API,
+  // rate-limit, missing commit). Falling through with an empty previousRanks
+  // would flag EVERY user as "NEW" below, wiping all rank arrows — and that
+  // gets persisted to JSON, so one transient hiccup sticks until the next clean
+  // run. When the snapshot is unusable, leave rank changes neutral instead of
+  // fabricating a board-wide "NEW".
+  if (!previousData || !Array.isArray(previousData)) {
+    console.warn(
+      `⚠️  No usable previous snapshot for ${filename}; leaving rank changes neutral (not marking users as NEW).`,
+    );
+    currentSorted.forEach((user) => {
+      user.rankChange = 0;
     });
+    return;
   }
+
+  previousData.forEach((user, idx) => {
+    previousRanks[user.id] = user.originalRank || idx + 1;
+  });
 
   currentSorted.forEach((user, idx) => {
     const currentRank = user.originalRank || idx + 1;


### PR DESCRIPTION
### Problem
`computeRankChanges()` in `scripts/sync-leaderboard.js` starts with an empty `previousRanks` and only fills it when `getYesterdaySnapshot()` returns an array. That helper returns `null` on **any** error (network, GitHub API, rate-limit, missing commit). On a transient failure `previousRanks` stays empty, so the loop hits `previousRanks[user.id] === undefined` for **every** user and sets `rankChange = "NEW"` — wiping all up/down arrows. Because the result is persisted to JSON, one hiccup sticks until the next clean run.

### Fix
Guard the null / non-array case: warn and leave rank changes neutral (`0`) instead of fabricating a board-wide `"NEW"`. When the previous snapshot genuinely loads, behaviour is unchanged.

### Notes
- Neutral `0` is the same value the existing delta-is-zero path already produces, so the frontend renders it as "no change" (not a false "NEW").
- Syntax-checked with `node --check`.

Closes #378