### PR TITLE
refactor: use backend streak data for HOT_STREAK badge evaluation

### DIFF
--- a/frontend/js/user/badges.js
+++ b/frontend/js/user/badges.js
@@ -14,7 +14,6 @@ const ALL_BADGES = [
     id: "TOP_BRASS",
     title: "Currently ranked in the top 10 on the overall leaderboard",
   },
-  ,
 ];
 
 export async function loadBadges(data) {
@@ -28,45 +27,12 @@ export async function loadBadges(data) {
     const ranks = data.leaderboardRanks || {};
     const earnedSet = new Set();
 
+    if (data.streak && data.streak.current >= 7) {
+      earnedSet.add("HOT_STREAK");
+    }
+
     if (history.length >= 8) {
       const recent = history.slice(-8, -1);
-      let streak = 0;
-      let isValid = true;
-
-      for (let j = 1; j < recent.length; j++) {
-        const todayTotals = recent[j].easy + recent[j].medium + recent[j].hard;
-        const yesterdayTotals =
-          recent[j - 1].easy + recent[j - 1].medium + recent[j - 1].hard;
-
-        if (todayTotals - yesterdayTotals >= 1) {
-          streak++;
-        } else {
-          isValid = false;
-          break;
-        }
-      }
-
-      if (isValid) {
-        const currentDay = history[history.length - 1];
-        const previousDay = history[history.length - 2];
-        const solvedToday =
-          currentDay.easy +
-            currentDay.medium +
-            currentDay.hard -
-            (previousDay.easy + previousDay.medium + previousDay.hard) >=
-          1;
-
-        if (solvedToday) {
-          streak++;
-        }
-      } else {
-        streak = 0;
-      }
-
-      if (streak >= 7) {
-        earnedSet.add("HOT_STREAK");
-      }
-
       const first = recent[0];
       const last = recent[recent.length - 1];
       const solvedHard = last.hard - first.hard;


### PR DESCRIPTION
## Description

Refactored the `HOT_STREAK` badge evaluation logic in `frontend/js/user/badges.js` to utilize the backend's precalculated streak data (`data.streak.current`) instead of manually traversing and recalculating streaks on the client-side history array, reducing code duplication and edge-case handling.

### Linked Issue

Fixes #360 

### Changes Made

- Removed the manual client-side history iteration loop used for calculating `HOT_STREAK`.
- Implemented a clean check `if (data.streak && data.streak.current >= 7)` to award the `HOT_STREAK` badge.
- Cleaned up trailing array comma syntax in `ALL_BADGES`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording