### PR TITLE
feat: distinguish 404 permanent failures from temporary API errors

### DIFF
--- a/scripts/analyze-inactivity.js
+++ b/scripts/analyze-inactivity.js
@@ -26,10 +26,11 @@ function atomicWrite(filePath, data) {
 async function fetchData(url) {
   try {
     const res = await axios.get(url, { timeout: 15000 });
-    return res.data;
+    return { data: res.data, status: res.status };
   } catch (err) {
-    console.error(`API failed for ${url}: ${err.message}`);
-    return null;
+    const status = err.response ? err.response.status : null;
+    console.error(`API failed for ${url} (Status: ${status}): ${err.message}`);
+    return { data: null, status };
   }
 }
 
@@ -58,6 +59,26 @@ async function fetchData(url) {
     }
   } catch (err) {
     console.warn("Failed to load activity-state.json, starting fresh cache.");
+  }
+
+  const invalidUsersFilePath = path.join(DATA_DIR, "invalid-users.json");
+  let invalidUsersMap = {};
+  try {
+    if (fs.existsSync(invalidUsersFilePath)) {
+      const existingInvalid = JSON.parse(
+        fs.readFileSync(invalidUsersFilePath, "utf8"),
+      );
+      const list = Array.isArray(existingInvalid)
+        ? existingInvalid
+        : existingInvalid.invalidUsers || [];
+      list.forEach((item) => {
+        const username = typeof item === "string" ? item : item.username;
+        if (username) invalidUsersMap[username] = item;
+      });
+      console.log("Loaded existing invalid-users.json.");
+    }
+  } catch (err) {
+    console.warn("Failed to load invalid-users.json, starting fresh.");
   }
 
   const baseUrl = "https://leetcode-api-dun.vercel.app/";
@@ -90,10 +111,26 @@ async function fetchData(url) {
           return;
         }
 
-        const profile = await fetchData(baseUrl + username);
+        const { data: profile, status } = await fetchData(baseUrl + username);
+
         if (!profile) {
-          console.log(`${username}: unreachable (API error after retries)`);
-          unreachableUsers.push(username);
+          if (status === 404) {
+            console.log(
+              `${username}: Invalid account (404 Not Found) - flagged for manual verification`,
+            );
+            if (!invalidUsersMap[username]) {
+              invalidUsersMap[username] = {
+                username,
+                flaggedAt: new Date().toISOString(),
+                reason: "HTTP 404 Not Found",
+              };
+            }
+          } else {
+            console.log(
+              `${username}: unreachable (API error status ${status} after retries)`,
+            );
+            unreachableUsers.push(username);
+          }
           return;
         }
 
@@ -156,6 +193,26 @@ async function fetchData(url) {
     console.log("Activity state cache updated successfully!");
   } catch (err) {
     console.error("Failed to write activity-state.json: ", err.message);
+    process.exit(1);
+  }
+
+  console.log("Writing manual verification list to invalid-users.json...");
+  try {
+    const invalidOutputArray = Object.values(invalidUsersMap).sort((a, b) => {
+      const nameA = typeof a === "string" ? a : a.username;
+      const nameB = typeof b === "string" ? b : b.username;
+      return nameA.localeCompare(nameB);
+    });
+
+    atomicWrite(invalidUsersFilePath, {
+      generatedAt: now.toISOString(),
+      invalidUsers: invalidOutputArray,
+    });
+    console.log(
+      "invalid-users.json updated successfully with manual verification entries!",
+    );
+  } catch (err) {
+    console.error("Failed to write invalid-users.json: ", err.message);
     process.exit(1);
   }
 })();

--- a/scripts/analyze-inactivity.js
+++ b/scripts/analyze-inactivity.js
@@ -28,9 +28,8 @@ async function fetchData(url) {
     const res = await axios.get(url, { timeout: 15000 });
     return { data: res.data, status: res.status };
   } catch (err) {
-    const status = err.response ? err.response.status : null;
-    console.error(`API failed for ${url} (Status: ${status}): ${err.message}`);
-    return { data: null, status };
+    console.error(`API failed for ${url}: ${err.message}`);
+    return { data: null, status: err.response?.status || 500 };
   }
 }
 
@@ -62,20 +61,23 @@ async function fetchData(url) {
   }
 
   const invalidUsersFilePath = path.join(DATA_DIR, "invalid-users.json");
-  let invalidUsersMap = {};
+  const invalidUsersMap = {};
   try {
     if (fs.existsSync(invalidUsersFilePath)) {
-      const existingInvalid = JSON.parse(
-        fs.readFileSync(invalidUsersFilePath, "utf8"),
-      );
-      const list = Array.isArray(existingInvalid)
-        ? existingInvalid
-        : existingInvalid.invalidUsers || [];
-      list.forEach((item) => {
-        const username = typeof item === "string" ? item : item.username;
-        if (username) invalidUsersMap[username] = item;
+      const rawInvalid = fs.readFileSync(invalidUsersFilePath, "utf8");
+      const parsed = JSON.parse(rawInvalid);
+      const list = Array.isArray(parsed) ? parsed : parsed.invalidUsers || [];
+      list.forEach((entry) => {
+        const u = typeof entry === "string" ? entry : entry.username;
+        invalidUsersMap[u] =
+          typeof entry === "string"
+            ? {
+                username: entry,
+                flaggedAt: new Date().toISOString(),
+                reason: "Existing entry",
+              }
+            : entry;
       });
-      console.log("Loaded existing invalid-users.json.");
     }
   } catch (err) {
     console.warn("Failed to load invalid-users.json, starting fresh.");
@@ -113,29 +115,49 @@ async function fetchData(url) {
 
         const { data: profile, status } = await fetchData(baseUrl + username);
 
-        if (!profile) {
-          if (status === 404) {
-            console.log(
-              `${username}: Invalid account (404 Not Found) - flagged for manual verification`,
-            );
-            if (!invalidUsersMap[username]) {
-              invalidUsersMap[username] = {
-                username,
-                flaggedAt: new Date().toISOString(),
-                reason: "HTTP 404 Not Found",
-              };
-            }
-          } else {
-            console.log(
-              `${username}: unreachable (API error status ${status} after retries)`,
-            );
-            unreachableUsers.push(username);
+        // Check for HTTP 404 OR HTTP 200 containing error payload ("does not exist")
+        // Check for HTTP 404 OR exact GraphQL error message from API
+        const isInvalidUser =
+          status === 404 ||
+          profile?.errors?.some(
+            (err) => err.message === "That user does not exist.",
+          );
+
+        if (isInvalidUser) {
+          console.log(
+            `${username}: Invalid account - flagged for manual verification`,
+          );
+          if (!invalidUsersMap[username]) {
+            invalidUsersMap[username] = {
+              username,
+              flaggedAt: new Date().toISOString(),
+              reason:
+                status === 404
+                  ? "HTTP 404 Not Found"
+                  : "API: That user does not exist.",
+            };
           }
           return;
         }
+        if (!profile) {
+          console.log(
+            `${username}: unreachable (API error status ${status} after retries)`,
+          );
+          unreachableUsers.push(username);
+          return;
+        }
 
-        const calendar = profile.submissionCalendar;
-        const timestamps = calendar ? Object.keys(calendar).map(Number) : [];
+        let calendarObj = profile.submissionCalendar;
+        if (typeof calendarObj === "string") {
+          try {
+            calendarObj = JSON.parse(calendarObj);
+          } catch (e) {
+            calendarObj = null;
+          }
+        }
+        const timestamps = calendarObj
+          ? Object.keys(calendarObj).map(Number)
+          : [];
 
         if (timestamps.length === 0) {
           console.log(`${username}: Inactive (no submission calendar history)`);
@@ -198,11 +220,9 @@ async function fetchData(url) {
 
   console.log("Writing manual verification list to invalid-users.json...");
   try {
-    const invalidOutputArray = Object.values(invalidUsersMap).sort((a, b) => {
-      const nameA = typeof a === "string" ? a : a.username;
-      const nameB = typeof b === "string" ? b : b.username;
-      return nameA.localeCompare(nameB);
-    });
+    const invalidOutputArray = Object.values(invalidUsersMap).sort((a, b) =>
+      a.username.localeCompare(b.username),
+    );
 
     atomicWrite(invalidUsersFilePath, {
       generatedAt: now.toISOString(),


### PR DESCRIPTION
## Description

Updated `scripts/analyze-inactivity.js` to distinguish between temporary API errors and permanent account deletions, routing `404` errors into `invalid-users.json` for manual verification.

### Linked Issue

Fixes #353 

### Changes Made

- Updated `fetchData` to return `{ data, status }`.
- Implemented logic to read, merge, and alphabetically sort entries in `invalid-users.json`.
- Separated `404` permanent account failures from temporary network/server failures in the sync loop.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [x] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording

N/A (Backend synchronization logic update)