### PR TITLE
fix(fetchUserInfo): add graceful fallback for live LeetCode API failures

### DIFF
--- a/scripts/fetch-user-info.js
+++ b/scripts/fetch-user-info.js
@@ -73,21 +73,27 @@ async function fetchUserInfo(username) {
 
   // 2. Fetch live profile ranking from the wrapper API
   let liveSolved = null;
-  const livePromise = fetchWithTimeout(liveApiUrl).then(async (res) => {
-    if (res.ok) {
-      const apiData = await res.json();
-      ranking = apiData.ranking || 0;
-      contest = apiData.contest || null;
-      liveSolved = {
-        easy: apiData.easySolved || 0,
-        medium: apiData.mediumSolved || 0,
-        hard: apiData.hardSolved || 0,
-      };
-    } else {
-      throw new Error(`LeetCode API wrapper returned status ${res.status}`);
-    }
-  });
-
+  const livePromise = fetchWithTimeout(liveApiUrl)
+    .then(async (res) => {
+      if (res.ok) {
+        const apiData = await res.json();
+        ranking = apiData.ranking || 0;
+        contest = apiData.contest || null;
+        liveSolved = {
+          easy: apiData.easySolved || 0,
+          medium: apiData.mediumSolved || 0,
+          hard: apiData.hardSolved || 0,
+        };
+      } else {
+        throw new Error(`LeetCode API wrapper returned status ${res.status}`);
+      }
+    })
+    .catch((err) => {
+      console.warn(
+        `Live LeetCode API unavailable for ${username}. Falling back to cached repository data. Reason:`,
+        err.message,
+      );
+    });
   // Wait for the live API task to complete
   await livePromise;
 


### PR DESCRIPTION
## Description

Makes the external LeetCode API fetch in `fetchUserInfo` graceful and optional. Previously, non-200 status codes (like 500 or 429) caused unhandled errors that crashed the entire data-fetching flow, preventing users from viewing cached history and badges.

### Linked Issue

Fixes #352

### Changes Made

- Added a local `.catch()` error handler to `livePromise` to gracefully catch and log external API failures.
- Prevented errors from propagating to ensure the function safely falls back to repository data instead of crashing.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] UI/Visual update
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Tested on mobile viewport (if applicable)
- [x] No console errors introduced

## Checklist

- [x] My code follows the project's coding style
- [x] I have formatted my code locally by running `npx prettier --write .` before submitting
- [x] I am submitting my PR from a dedicated `feature/*` branch, not the `main` branch
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if required
- [x] I have linked the relevant issue

## Screenshots / Screen Recording